### PR TITLE
Define how filler failure is managed in quote responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,24 @@ TypeScript-friendly interfaces are provided in `schemas/typescript/`:
 - `schemas/typescript/get-quote.ts`
 - `schemas/typescript/intent.ts`
 
+### Failure handling semantics
+
+Providers may include an optional `failureHandling` field on each quote to indicate how execution failures are managed. It supports:
+
+- A simple mode: `retry`, `refund-instant`, `refund-claim`, `needs-new-signature`.
+- A structured form to combine partial fills with a remainder policy:
+
+```json
+{
+  "failureHandling": {
+    "partialFill": true,
+    "remainder": "refund-claim"
+  }
+}
+```
+
+In the object form, `partialFill` defaults to false if omitted; `remainder` is required and uses a simple mode.
+
 ## How to view the OpenAPI without running anything locally
 
 Use any of the following online viewers. After this repo is public, you can point them directly to the raw `openapi.yaml` URL; until then, copy-paste the YAML content into the viewer.

--- a/schemas/typescript/get-quote.ts
+++ b/schemas/typescript/get-quote.ts
@@ -41,6 +41,26 @@ export type QuotePreference =
   | 'input-priority'
   | 'trust-minimization';
 
+/**
+ * Failure handling policy. For backward compatibility, simple modes can be
+ * provided as a string. To express partial fills in combination with a
+ * remainder policy, use the object form.
+ */
+export type FailureHandlingMode =
+  | 'retry'
+  | 'refund-instant'
+  | 'refund-claim'
+  | 'needs-new-signature';
+
+export type FailureHandling =
+  | FailureHandlingMode
+  | {
+      /** Whether partial execution may occur. Defaults to false if omitted. */
+      partialFill?: boolean;
+      /** How the missing portion is handled if a partial fill occurs. */
+      remainder: FailureHandlingMode;
+    };
+
 export interface GetQuoteRequest {
   user: Address;
   /** Order of inputs is significant if preference is 'input-priority'. */
@@ -83,6 +103,8 @@ export interface Quote {
   eta?: number;
   quoteId: string;
   provider: string;
+  /** How this provider handles failures during execution. */
+  failureHandling?: FailureHandling;
 }
 
 export interface GetQuoteResponse {
@@ -154,6 +176,8 @@ export interface GetQuoteResponse {
     eta?: number;
     quoteId: string;
     provider: string;
+    /** How this provider handles failures during execution. */
+    failureHandling?: FailureHandling;
   }>;
 }
 

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -120,6 +120,24 @@ components:
       type: string
       enum: [price, speed, input-priority, trust-minimization]
 
+    FailureHandlingMode:
+      type: string
+      description: Base failure handling mode
+      enum: [retry, refund-instant, refund-claim, needs-new-signature]
+
+    FailureHandling:
+      description: How the provider handles failures during execution
+      oneOf:
+        - $ref: '#/components/schemas/FailureHandlingMode'
+        - type: object
+          properties:
+            partialFill:
+              type: boolean
+              description: Whether partial execution may occur
+            remainder:
+              $ref: '#/components/schemas/FailureHandlingMode'
+          required: [remainder]
+
     GetQuoteRequest:
       type: object
       properties:
@@ -198,6 +216,8 @@ components:
           type: string
         provider:
           type: string
+        failureHandling:
+          $ref: '#/components/schemas/FailureHandling'
       required: [orders, details, quoteId, provider]
 
     GetQuoteResponse:


### PR DESCRIPTION
Adds an optional failureHandling field to quotes that communicates how a provider handles execution failures. Supports both simple modes and a structured form that combines partial fills with a specified remainder policy.

Examples

Simple mode:
```
{
  "failureHandling": "refund-instant"
}
```

Partial fill with a remainder policy:
```
{
  "failureHandling": {
    "partialFill": true,
    "remainder": "refund-claim"
  }
}
```

resolves https://github.com/openintentsframework/oif-specs/issues/6