### PR TITLE
Define how the user specifies how an order is exact input vs exact output

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,27 @@ TypeScript-friendly interfaces are provided in `schemas/typescript/`:
 - `schemas/typescript/get-quote.ts`
 - `schemas/typescript/intent.ts`
 
+### Order types and exactness
+
+Requests must include an `orderType` string to indicate how intents and amounts should be interpreted. The API is open-ended for future order types; current recognized values are:
+
+- `swap-exact-input`: available input amounts are exact; requested output amounts are minimums (at least this amount, subject to slippage).
+- `swap-exact-output`: requested output amounts are exact; available input amounts are maximums (spend up to this amount).
+
+Example request shape (abridged):
+
+```json
+{
+  "user": "0x...",
+  "availableInputs": [{ "user": "0x...", "asset": "0xTokenIn", "amount": "1000000000000000000" }],
+  "requestedOutputs": [{ "receiver": "0x...", "asset": "0xTokenOut", "amount": "990000000000000000" }],
+  "orderType": "swap-exact-input",
+  "preference": "price"
+}
+```
+
+See `components.schemas.OrderType` in `specs/openapi.yaml` for the authoritative definition.
+
 ## How to view the OpenAPI without running anything locally
 
 Use any of the following online viewers. After this repo is public, you can point them directly to the raw `openapi.yaml` URL; until then, copy-paste the YAML content into the viewer.

--- a/schemas/typescript/get-quote.ts
+++ b/schemas/typescript/get-quote.ts
@@ -41,6 +41,15 @@ export type QuotePreference =
   | 'input-priority'
   | 'trust-minimization';
 
+/**
+ * Generic order type discriminator.
+ * Current recognized values:
+ * - 'swap-exact-input': input amounts are exact; output amounts in requestedOutputs are minimums.
+ * - 'swap-exact-output': output amounts are exact; input amounts in availableInputs are maximums.
+ * The API is open-ended and future order types may be introduced without breaking changes.
+ */
+export type OrderType = string;
+
 export interface GetQuoteRequest {
   user: Address;
   /** Order of inputs is significant if preference is 'input-priority'. */
@@ -49,6 +58,8 @@ export interface GetQuoteRequest {
   /** Minimum validity timestamp (seconds). */
   minValidUntil?: number;
   preference?: QuotePreference;
+  /** See OrderType for semantics regarding exact-input vs exact-output. */
+  orderType: OrderType;
 }
 
 export interface Eip712Order {
@@ -121,6 +132,12 @@ export interface GetQuoteRequest {
   }>;
   minValidUntil?: number;
   preference?: 'price' | 'speed' | 'input-priority' | 'trust-minimization';
+  /**
+   * Generic order type discriminator. Current recognized values:
+   * - 'swap-exact-input': input amounts are exact; requested output amounts are minimums.
+   * - 'swap-exact-output': output amounts are exact; available input amounts are maximums.
+   */
+  orderType: string;
 }
 
 export interface EIP712OrderEnvelope {

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -120,6 +120,14 @@ components:
       type: string
       enum: [price, speed, input-priority, trust-minimization]
 
+    OrderType:
+      type: string
+      description: |
+        Generic order type discriminator. Current recognized values:
+        - 'swap-exact-input': input amounts are exact; output amounts in requestedOutputs are minimums.
+        - 'swap-exact-output': output amounts are exact; input amounts in availableInputs are maximums.
+        This field is open-ended and future order types may be introduced without breaking changes.
+
     GetQuoteRequest:
       type: object
       properties:
@@ -139,7 +147,9 @@ components:
           description: Minimum validity timestamp (seconds)
         preference:
           $ref: '#/components/schemas/QuotePreference'
-      required: [user, availableInputs, requestedOutputs]
+        orderType:
+          $ref: '#/components/schemas/OrderType'
+      required: [user, availableInputs, requestedOutputs, orderType]
 
     Eip712Order:
       type: object


### PR DESCRIPTION
Fixes https://github.com/openintentsframework/oif-specs/issues/7

Introduce orderType to define whether a swap is exact-input or exact-output, and make it explicit and future-proof across the API and TS schemas.

Goals:

- Clarify how providers interpret amounts for swaps.
- Keep the API flexible for future order types while documenting current conventions.
