### PR TITLE
Allow for gassless interaction preference on quote request

### DIFF
--- a/schemas/typescript/get-quote.ts
+++ b/schemas/typescript/get-quote.ts
@@ -41,6 +41,27 @@ export type QuotePreference =
   | 'input-priority'
   | 'trust-minimization';
 
+export type OriginSubmissionMode = 'user' | 'protocol';
+export type OriginAuthorizationScheme =
+  | 'erc-4337'
+  | 'permit2'
+  | 'erc20-permit'
+  | 'eip-3009';
+
+/**
+ * Preference for how the origin transaction should be submitted.
+ * If omitted, the provider may choose either based on capabilities.
+ */
+export interface OriginSubmissionPreference {
+  /**
+   * 'user' means the requester intends to handle origin submission (may pay gas or use their own abstraction).
+   * 'protocol' means the requester prefers the protocol/provider to submit (gasless for the user).
+   */
+  mode: OriginSubmissionMode;
+  /** Optional list of acceptable authorization schemes if protocol submission is requested. */
+  schemes?: OriginAuthorizationScheme[];
+}
+
 export interface GetQuoteRequest {
   user: Address;
   /** Order of inputs is significant if preference is 'input-priority'. */
@@ -49,6 +70,8 @@ export interface GetQuoteRequest {
   /** Minimum validity timestamp (seconds). */
   minValidUntil?: number;
   preference?: QuotePreference;
+  /** Optional preference indicating whether the user wants protocol-submitted (gasless) execution. */
+  originSubmission?: OriginSubmissionPreference;
 }
 
 export interface Eip712Order {
@@ -73,6 +96,13 @@ export interface QuoteDetails {
   >;
 }
 
+export interface OriginSubmissionPlan {
+  /** Mode the provider expects to use for origin submission. */
+  mode: OriginSubmissionMode;
+  /** Selected authorization scheme if applicable (e.g., when mode is 'protocol'). */
+  scheme?: OriginAuthorizationScheme;
+}
+
 export interface Quote {
   /** One or more EIP-712 compliant orders. */
   orders: Eip712Order[];
@@ -83,6 +113,8 @@ export interface Quote {
   eta?: number;
   quoteId: string;
   provider: string;
+  /** Plan for how origin submission will be handled for this quote. */
+  originSubmission?: OriginSubmissionPlan;
 }
 
 export interface GetQuoteResponse {
@@ -121,6 +153,10 @@ export interface GetQuoteRequest {
   }>;
   minValidUntil?: number;
   preference?: 'price' | 'speed' | 'input-priority' | 'trust-minimization';
+  originSubmission?: {
+    mode: 'user' | 'protocol';
+    schemes?: Array<'erc-4337' | 'permit2' | 'erc20-permit' | 'eip-3009'>;
+  };
 }
 
 export interface EIP712OrderEnvelope {
@@ -154,6 +190,10 @@ export interface GetQuoteResponse {
     eta?: number;
     quoteId: string;
     provider: string;
+    originSubmission?: {
+      mode: 'user' | 'protocol';
+      scheme?: 'erc-4337' | 'permit2' | 'erc20-permit' | 'eip-3009';
+    };
   }>;
 }
 

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -120,6 +120,29 @@ components:
       type: string
       enum: [price, speed, input-priority, trust-minimization]
 
+    OriginSubmissionMode:
+      type: string
+      description: Preference for who submits the origin transaction
+      enum: [user, protocol]
+
+    OriginAuthorizationScheme:
+      type: string
+      description: Preferred authorization scheme when provider submits
+      enum: [erc-4337, permit2, erc20-permit, eip-3009]
+
+    OriginSubmissionPreference:
+      type: object
+      description: Preference for origin submission (gasless vs user-submitted)
+      properties:
+        mode:
+          $ref: '#/components/schemas/OriginSubmissionMode'
+        schemes:
+          type: array
+          description: Acceptable authorization schemes when mode is 'protocol'
+          items:
+            $ref: '#/components/schemas/OriginAuthorizationScheme'
+      required: [mode]
+
     GetQuoteRequest:
       type: object
       properties:
@@ -139,6 +162,8 @@ components:
           description: Minimum validity timestamp (seconds)
         preference:
           $ref: '#/components/schemas/QuotePreference'
+        originSubmission:
+          $ref: '#/components/schemas/OriginSubmissionPreference'
       required: [user, availableInputs, requestedOutputs]
 
     Eip712Order:
@@ -198,6 +223,14 @@ components:
           type: string
         provider:
           type: string
+        originSubmission:
+          type: object
+          description: Plan for how origin submission will be handled for this quote
+          properties:
+            mode:
+              $ref: '#/components/schemas/OriginSubmissionMode'
+            scheme:
+              $ref: '#/components/schemas/OriginAuthorizationScheme'
       required: [orders, details, quoteId, provider]
 
     GetQuoteResponse:


### PR DESCRIPTION
Closes https://github.com/openintentsframework/oif-specs/issues/5

Adds an explicit, forward-compatible way to express user preference for gasless execution and how origin submission should be handled.


Rationale
- **Is a bool enough**? No. We need to distinguish “who submits” and optionally constrain acceptable authorization schemes for interoperability/integration needs.
- **Should we specify paymaster type?** We don’t expose low-level paymaster details; instead, we expose high-level authorization schemes. This keeps the API stable while allowing providers to pick underlying mechanics. If needed later, we can refine with additional scheme variants or metadata.
- **Alignment with lock**: orthogonal. lock = asset state; originSubmission = submission responsibility and signing/authorization surface.
