### PR TITLE
Allow for gassless interaction preference on quote request

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,26 @@ Authoritative schema: `specs/openapi.yaml`
 
 TypeScript-friendly interfaces are provided in `schemas/typescript/types.ts`
 
+### Origin submission preference
+
+To express user preference for gasless execution and who submits the origin transaction, use `originSubmission`:
+
+```json
+{
+  "originSubmission": {
+    "mode": "user", // or "protocol"
+    "schemes": ["erc-4337", "permit2", "erc20-permit", "eip-3009"]
+  }
+}
+```
+
+- **mode**: who is expected to submit the origin transaction.
+- **schemes**: acceptable signing/authorization schemes for interoperability.
+
+Notes:
+- This is orthogonal to `lock` (asset state) and focuses on submission responsibility and signing surface.
+- The legacy `fillerPerformsOpen` boolean is deprecated. Prefer `originSubmission` for forward compatibility.
+
 ## Generating OpenAPI from TypeScript
 
 The OpenAPI specification is auto-generated from TypeScript types using a TypeScript → Zod → OpenAPI pipeline. To regenerate:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ To express user preference for gasless execution and who submits the origin tran
 
 Notes:
 - This is orthogonal to `lock` (asset state) and focuses on submission responsibility and signing surface.
-- The legacy `fillerPerformsOpen` boolean is deprecated. Prefer `originSubmission` for forward compatibility.
 
 ## Generating OpenAPI from TypeScript
 

--- a/schemas/typescript/intent.ts
+++ b/schemas/typescript/intent.ts
@@ -8,4 +8,5 @@ export {
   IntentResponse,
   FailureHandling,
   FailureHandlingMode,
+  OriginSubmission,
 } from "./types";

--- a/schemas/typescript/quote.ts
+++ b/schemas/typescript/quote.ts
@@ -17,4 +17,5 @@ export {
   QuoteDetails,
   Quote,
   GetQuoteResponse,
+  OriginSubmission,
 } from "./types";

--- a/schemas/typescript/schemas.generated.ts
+++ b/schemas/typescript/schemas.generated.ts
@@ -20,6 +20,20 @@ export const assetLockReferenceSchema = z.object({
   params: z.record(z.unknown()).optional(),
 });
 
+export const originSubmissionSchema = z.object({
+  mode: z.union([z.literal("user"), z.literal("protocol")]),
+  schemes: z
+    .array(
+      z.union([
+        z.literal("erc-4337"),
+        z.literal("permit2"),
+        z.literal("erc20-permit"),
+        z.literal("eip-3009"),
+      ]),
+    )
+    .optional(),
+});
+
 export const availableInputSchema = z.object({
   user: addressSchema,
   asset: addressSchema,
@@ -71,6 +85,7 @@ export const getQuoteRequestSchema = z.object({
   requestedOutputs: z.array(requestedOutputSchema),
   minValidUntil: z.number().optional(),
   preference: quotePreferenceSchema.optional(),
+  originSubmission: originSubmissionSchema.optional(),
   fillerPerformsOpen: z.boolean().optional(),
 });
 
@@ -111,6 +126,7 @@ export const intentRequestSchema = z.object({
   quoteId: z.string().optional(),
   provider: z.string(),
   failureHandling: failureHandlingSchema,
+  originSubmission: originSubmissionSchema.optional(),
 });
 
 export const intentResponseSchema = z.object({

--- a/schemas/typescript/types.ts
+++ b/schemas/typescript/types.ts
@@ -32,6 +32,17 @@ export interface AssetLockReference {
   params?: Record<string, unknown>;
 }
 
+/**
+ * Origin submission preference
+ * @description Explicit, forward-compatible preference for who submits the origin transaction and acceptable authorization schemes.
+ */
+export interface OriginSubmission {
+  /** Who submits the origin transaction */
+  mode: "user" | "protocol";
+  /** Acceptable signing/authorization schemes for interoperability */
+  schemes?: Array<"erc-4337" | "permit2" | "erc20-permit" | "eip-3009">;
+}
+
 // ============ Quote Types ============
 
 /**
@@ -124,7 +135,15 @@ export interface GetQuoteRequest {
   minValidUntil?: number;
   /** Quote preference */
   preference?: QuotePreference;
-  /** If true, request the filler to perform the open on the source chain (may entail additional gas fees). */
+  /**
+   * Explicit preference for submission responsibility and acceptable auth schemes.
+   * If provided, takes precedence over the legacy boolean.
+   */
+  originSubmission?: OriginSubmission;
+  /**
+   * @deprecated Legacy flag. Use originSubmission instead to specify submitter and schemes.
+   * If true, request the protocol/filler to perform the open on the source chain (may entail additional gas fees).
+   */
   fillerPerformsOpen?: boolean;
 }
 
@@ -206,6 +225,8 @@ export interface IntentRequest {
   provider: string;
   /** Failure handling policy for execution */
   failureHandling: FailureHandling;
+  /** Optional preference mirrored from quote about who submits and acceptable schemes */
+  originSubmission?: OriginSubmission;
 }
 
 /**

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -217,6 +217,35 @@ components:
               enum:
                 - trust-minimization
           description: Quote preference type
+        originSubmission:
+          type: object
+          properties:
+            mode:
+              anyOf:
+                - type: string
+                  enum:
+                    - user
+                - type: string
+                  enum:
+                    - protocol
+            schemes:
+              type: array
+              items:
+                anyOf:
+                  - type: string
+                    enum:
+                      - erc-4337
+                  - type: string
+                    enum:
+                      - permit2
+                  - type: string
+                    enum:
+                      - erc20-permit
+                  - type: string
+                    enum:
+                      - eip-3009
+          required:
+            - mode
         fillerPerformsOpen:
           type: boolean
       required:
@@ -528,6 +557,35 @@ components:
                         - needs-new-signature
               required:
                 - remainder
+        originSubmission:
+          type: object
+          properties:
+            mode:
+              anyOf:
+                - type: string
+                  enum:
+                    - user
+                - type: string
+                  enum:
+                    - protocol
+            schemes:
+              type: array
+              items:
+                anyOf:
+                  - type: string
+                    enum:
+                      - erc-4337
+                  - type: string
+                    enum:
+                      - permit2
+                  - type: string
+                    enum:
+                      - erc20-permit
+                  - type: string
+                    enum:
+                      - eip-3009
+          required:
+            - mode
       required:
         - order
         - signature
@@ -644,6 +702,35 @@ paths:
                       enum:
                         - trust-minimization
                   description: Quote preference type
+                originSubmission:
+                  type: object
+                  properties:
+                    mode:
+                      anyOf:
+                        - type: string
+                          enum:
+                            - user
+                        - type: string
+                          enum:
+                            - protocol
+                    schemes:
+                      type: array
+                      items:
+                        anyOf:
+                          - type: string
+                            enum:
+                              - erc-4337
+                          - type: string
+                            enum:
+                              - permit2
+                          - type: string
+                            enum:
+                              - erc20-permit
+                          - type: string
+                            enum:
+                              - eip-3009
+                  required:
+                    - mode
                 fillerPerformsOpen:
                   type: boolean
               required:
@@ -813,6 +900,35 @@ paths:
                                 - needs-new-signature
                       required:
                         - remainder
+                originSubmission:
+                  type: object
+                  properties:
+                    mode:
+                      anyOf:
+                        - type: string
+                          enum:
+                            - user
+                        - type: string
+                          enum:
+                            - protocol
+                    schemes:
+                      type: array
+                      items:
+                        anyOf:
+                          - type: string
+                            enum:
+                              - erc-4337
+                          - type: string
+                            enum:
+                              - permit2
+                          - type: string
+                            enum:
+                              - erc20-permit
+                          - type: string
+                            enum:
+                              - eip-3009
+                  required:
+                    - mode
               required:
                 - order
                 - signature


### PR DESCRIPTION
Closes https://github.com/openintentsframework/oif-specs/issues/5

Adds an explicit, forward-compatible way to express user preference for gasless execution and how origin submission should be handled.

Rationale

Is a bool enough? No. We need to distinguish “who submits” and optionally constrain acceptable authorization schemes for interoperability/integration needs.
Should we specify paymaster type? We don’t expose low-level paymaster details; instead, we expose high-level authorization schemes. This keeps the API stable while allowing providers to pick underlying mechanics. If needed later, we can refine with additional scheme variants or metadata.
Alignment with lock: orthogonal. lock = asset state; originSubmission = submission responsibility and signing/authorization surface.