### PR TITLE
Define how the user specifies how an order is exact input vs exact output

### DIFF
--- a/schemas/typescript/quote.ts
+++ b/schemas/typescript/quote.ts
@@ -6,6 +6,7 @@
 export {
   Address,
   Amount,
+  OrderType,
   AssetLockReference,
   AvailableInput,
   RequestedOutput,

--- a/schemas/typescript/schemas.generated.ts
+++ b/schemas/typescript/schemas.generated.ts
@@ -15,6 +15,12 @@ export const amountSchema = z
     "Integer encoded as a string to preserve precision (e.g., uint256)",
   );
 
+export const orderTypeSchema = z
+  .union([z.literal("swap-buy"), z.literal("swap-sell")])
+  .describe(
+    'Closed list defining how providers must interpret amounts for swaps. "swap-sell" means exact-input (spend exactly the input amounts). "swap-buy" means exact-output (receive exactly the output amounts). To include more options the API will be extended in the future.',
+  );
+
 export const assetLockReferenceSchema = z.object({
   kind: z.union([z.literal("the-compact"), z.literal("rhinestone")]),
   params: z.record(z.unknown()).optional(),
@@ -69,6 +75,7 @@ export const getQuoteRequestSchema = z.object({
   user: addressSchema,
   availableInputs: z.array(availableInputSchema),
   requestedOutputs: z.array(requestedOutputSchema),
+  orderType: orderTypeSchema.optional(),
   minValidUntil: z.number().optional(),
   preference: quotePreferenceSchema.optional(),
   fillerPerformsOpen: z.boolean().optional(),

--- a/schemas/typescript/types.ts
+++ b/schemas/typescript/types.ts
@@ -22,6 +22,14 @@ export type Address = string;
 export type Amount = string;
 
 /**
+ * Order interpretation for swap amounts
+ * @description Closed list defining how providers must interpret amounts for swaps. "swap-sell" means exact-input (spend exactly the input amounts). "swap-buy" means exact-output (receive exactly the output amounts). To include more options the API will be extended in the future.
+ */
+export type OrderType =
+  | "swap-buy"
+  | "swap-sell";
+
+/**
  * Reference to a lock in a locking system
  * @description Reference to a lock in a locking system
  */
@@ -120,6 +128,8 @@ export interface GetQuoteRequest {
   availableInputs: AvailableInput[];
   /** Requested outputs for the quote */
   requestedOutputs: RequestedOutput[];
+  /** Order type: 'swap-sell' = exact-input, 'swap-buy' = exact-output. If omitted, providers SHOULD assume 'swap-sell' for backward compatibility. */
+  orderType?: OrderType;
   /** Minimum validity timestamp in seconds */
   minValidUntil?: number;
   /** Quote preference */

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -18,6 +18,7 @@ const registry = new OpenAPIRegistry();
 // Register all schemas as components
 registry.register('Address', schemas.addressSchema);
 registry.register('Amount', schemas.amountSchema);
+registry.register('OrderType', schemas.orderTypeSchema);
 registry.register('AssetLockReference', schemas.assetLockReferenceSchema);
 registry.register('AvailableInput', schemas.availableInputSchema);
 registry.register('RequestedOutput', schemas.requestedOutputSchema);

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -22,6 +22,15 @@ components:
       type: string
       pattern: ^[0-9]+$
       description: Integer encoded as a string to preserve precision (e.g., uint256)
+    OrderType:
+      anyOf:
+        - type: string
+          enum:
+            - swap-buy
+        - type: string
+          enum:
+            - swap-sell
+      description: Closed list defining how providers must interpret amounts for swaps. "swap-sell" means exact-input (spend exactly the input amounts). "swap-buy" means exact-output (receive exactly the output amounts). To include more options the API will be extended in the future.
     AssetLockReference:
       type: object
       properties:
@@ -200,6 +209,15 @@ components:
               - receiver
               - asset
               - amount
+        orderType:
+          anyOf:
+            - type: string
+              enum:
+                - swap-buy
+            - type: string
+              enum:
+                - swap-sell
+          description: Closed list defining how providers must interpret amounts for swaps. "swap-sell" means exact-input (spend exactly the input amounts). "swap-buy" means exact-output (receive exactly the output amounts). To include more options the API will be extended in the future.
         minValidUntil:
           type: number
         preference:
@@ -627,6 +645,15 @@ paths:
                       - receiver
                       - asset
                       - amount
+                orderType:
+                  anyOf:
+                    - type: string
+                      enum:
+                        - swap-buy
+                    - type: string
+                      enum:
+                        - swap-sell
+                  description: Closed list defining how providers must interpret amounts for swaps. "swap-sell" means exact-input (spend exactly the input amounts). "swap-buy" means exact-output (receive exactly the output amounts). To include more options the API will be extended in the future.
                 minValidUntil:
                   type: number
                 preference:


### PR DESCRIPTION
Fixes https://github.com/openintentsframework/oif-specs/issues/7

Introduce orderType to define whether a swap is exact-input or exact-output