### PR TITLE
human-legible CAIP-350 text identifiers for chains and addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,48 @@ It includes:
 - `schemas/typescript/schemas.generated.ts`: Auto-generated Zod schemas from TypeScript types
 - `docs/references.md`: Curated external references to related off-chain APIs and intent protocols
 
+## Address format (CAIP-350)
+
+OIF uses **CAIP-350 text identifiers** for chain-specific addresses in the API. This provides a human-readable, integrator-friendly format that is easy to work with.
+
+### ChainAddress format
+
+All addresses in the API use the `ChainAddress` object format:
+
+```json
+{
+  "chain": "eip155:8453",
+  "address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+}
+```
+
+- **chain**: CAIP-2 chain identifier (e.g., `eip155:1` for Ethereum, `eip155:8453` for Base)
+- **address**: Native address format (e.g., `0x...` for EVM chains)
+
+### Examples
+
+```json
+// USDC on Ethereum mainnet
+{
+  "chain": "eip155:1",
+  "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+}
+
+// vitalik.eth on Base
+{
+  "chain": "eip155:8453",
+  "address": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+}
+```
+
+### Related standards
+
+- [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md): Chain identifier format
+- [CAIP-10](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-10.md): Account identifier format
+- [CAIP-350](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-350.md): Text identifier for chain-specific addresses
+
+> **Note**: On-chain contracts (oif-contracts) continue to use ERC-7930 binary format for gas efficiency. Solvers and tooling handle the conversion between text (API) and binary (on-chain) representations.
+
 ## API standards
 
 This repository defines the following endpoints:
@@ -23,7 +65,7 @@ This repository defines the following endpoints:
 - **Intent**: submit a previously quoted, signed order for execution
 - **Asset Discovery**: discover supported assets and chains
   - `GET /api/tokens`: returns all supported assets across all configured blockchain networks
-  - `GET /api/tokens/{chain_id}`: returns supported assets for a specific blockchain network
+  - `GET /api/tokens/{chain}`: returns supported assets for a specific chain (e.g., `eip155:1`)
 
 Authoritative schema: `specs/openapi.yaml`
 
@@ -54,9 +96,28 @@ Notes:
 To discover which assets and chains are supported by a provider, use the asset discovery endpoints:
 
 - `GET /api/tokens`: Returns all supported networks and their assets
-- `GET /api/tokens/{chain_id}`: Returns assets for a specific chain
+- `GET /api/tokens/{chain}`: Returns assets for a specific chain (e.g., `eip155:1`)
 
-The response includes asset metadata (address in EIP-7930 format, symbol, and decimals) for each supported network. This enables clients to build asset and chain selection UIs and validate that a provider can theoretically fulfill a given intent before requesting quotes.
+The response includes asset metadata (address in CAIP-350 format, symbol, and decimals) for each supported network. This enables clients to build asset and chain selection UIs and validate that a provider can theoretically fulfill a given intent before requesting quotes.
+
+Example response:
+
+```json
+{
+  "networks": {
+    "eip155:1": {
+      "chain": "eip155:1",
+      "assets": [
+        {
+          "address": { "chain": "eip155:1", "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" },
+          "symbol": "USDC",
+          "decimals": 6
+        }
+      ]
+    }
+  }
+}
+```
 
 ## Generating OpenAPI from TypeScript
 

--- a/docs/references.md
+++ b/docs/references.md
@@ -13,7 +13,7 @@ Below is a curated list of external APIs and docs that are relevant to OIF's quo
   - Relevance: combines chain and address into a single identifier string
 
 - CAIP-350 — Text Identifiers for Chain-Specific Addresses: `https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-350.md`
-  - Focus: text representation of chain-specific addresses
+  - Focus: specifying deterministic and unambiguous conversions between text and binary formats for Addresses and Chain References across different blockchain ecosystems
   - Relevance: OIF API uses CAIP-350 format for all addresses (ChainAddress type)
 
 - ERC-7930 — Interoperable Addresses: `https://eips.ethereum.org/EIPS/eip-7930`

--- a/docs/references.md
+++ b/docs/references.md
@@ -2,6 +2,26 @@
 
 Below is a curated list of external APIs and docs that are relevant to OIF's quote and intent standards. These are for inspiration and comparison; they are not normative for OIF.
 
+## Chain and Address Standards
+
+- CAIP-2 — Chain ID Specification: `https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md`
+  - Focus: blockchain-agnostic chain identifier format
+  - Relevance: OIF uses CAIP-2 for the `chain` field in addresses (e.g., `eip155:1`)
+
+- CAIP-10 — Account ID Specification: `https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-10.md`
+  - Focus: blockchain-agnostic account identifier format
+  - Relevance: combines chain and address into a single identifier string
+
+- CAIP-350 — Text Identifiers for Chain-Specific Addresses: `https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-350.md`
+  - Focus: text representation of chain-specific addresses
+  - Relevance: OIF API uses CAIP-350 format for all addresses (ChainAddress type)
+
+- ERC-7930 — Interoperable Addresses: `https://eips.ethereum.org/EIPS/eip-7930`
+  - Focus: compact binary chain-specific address format
+  - Note: Used by oif-contracts for on-chain representation; solvers handle conversion from CAIP-350 text format
+
+## Intent and Quote APIs
+
 - Across Protocol — API Reference: `https://docs.across.to/reference/api-reference#api-endpoints`
   - Focus: cross-chain bridge quotes, relays, fees and ETA
   - Relevance: quote semantics, response fields (validity, fees, timing)
@@ -20,5 +40,3 @@ Below is a curated list of external APIs and docs that are relevant to OIF's quo
 
 - LI.FI Catalyst — Intents API: reference link pending
   - If you have a canonical public URL, please open a PR to add it here.
-
-

--- a/docs/references.md
+++ b/docs/references.md
@@ -14,7 +14,7 @@ Below is a curated list of external APIs and docs that are relevant to OIF's quo
 
 - CAIP-350 — Text Identifiers for Chain-Specific Addresses: `https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-350.md`
   - Focus: specifying deterministic and unambiguous conversions between text and binary formats for Addresses and Chain References across different blockchain ecosystems
-  - Relevance: OIF API uses CAIP-350 format for all addresses (ChainAddress type)
+  - Relevance: OIF API uses CAIP-350's text representations for chain identifiers and addresses to identify tokens and accounts on specific chains
 
 - ERC-7930 — Interoperable Addresses: `https://eips.ethereum.org/EIPS/eip-7930`
   - Focus: compact binary chain-specific address format

--- a/docs/references.md
+++ b/docs/references.md
@@ -18,7 +18,7 @@ Below is a curated list of external APIs and docs that are relevant to OIF's quo
 
 - ERC-7930 — Interoperable Addresses: `https://eips.ethereum.org/EIPS/eip-7930`
   - Focus: compact binary chain-specific address format
-  - Note: Used by oif-contracts for on-chain representation; solvers handle conversion from CAIP-350 text format
+  - Note: Used by oif-contracts for on-chain representation; solvers handle conversion between this binary format and the corresponding text representation
 
 ## Intent and Quote APIs
 

--- a/schemas/typescript/orders.ts
+++ b/schemas/typescript/orders.ts
@@ -25,8 +25,10 @@ export {
   Settlement,
   SettlementType,
   
-  // Common types
-  Address,
+  // Common types - CAIP-350 address format
+  Chain,
+  NativeAddress,
+  ChainAddress,
   Amount,
   OriginSubmission,
   FailureHandlingMode,

--- a/schemas/typescript/quotes.ts
+++ b/schemas/typescript/quotes.ts
@@ -4,8 +4,10 @@
  */
 
 export {
-  // Common types
-  Address,
+  // Common types - CAIP-350 address format
+  Chain,
+  NativeAddress,
+  ChainAddress,
   Amount,
   SwapType,
   

--- a/schemas/typescript/schemas.generated.ts
+++ b/schemas/typescript/schemas.generated.ts
@@ -2,12 +2,26 @@
 import { z } from "zod";
 import { PostOrderResponseStatus, OrderStatus, SettlementType } from "./types";
 
-export const addressSchema = z
+export const chainSchema = z
   .string()
-  .regex(/^0x0001[a-fA-F0-9]+$/)
   .describe(
-    "Cross-chain compatible address format per EIP-7930 version 1 encoded format (0x0001 + chain ID + address) for\nunambiguous cross-chain identification.",
+    "Chain identifier following CAIP-2 standard (namespace:reference format).\nFor EVM chains, uses eip155 namespace with chain ID.",
   );
+
+export const nativeAddressSchema = z
+  .string()
+  .describe(
+    "Native blockchain address in its canonical format for the specified chain.\nFormat varies by chain namespace.",
+  );
+
+export const chainAddressSchema = z.object({
+  chain: chainSchema.describe(
+    "The blockchain network identifier in CAIP-2 format (namespace:reference)",
+  ),
+  address: nativeAddressSchema.describe(
+    "The address in its native format for the specified chain",
+  ),
+});
 
 export const amountSchema = z
   .string()
@@ -65,8 +79,12 @@ export const originSubmissionSchema = z.object({
 });
 
 export const inputSchema = z.object({
-  user: addressSchema.describe("The address providing the input assets"),
-  asset: addressSchema.describe("The token/asset being provided as input"),
+  user: chainAddressSchema.describe(
+    "The CAIP-350 address of the user providing the input assets",
+  ),
+  asset: chainAddressSchema.describe(
+    "The CAIP-350 address of the token/asset being provided as input",
+  ),
   amount: amountSchema
     .optional()
     .describe(
@@ -78,10 +96,12 @@ export const inputSchema = z.object({
 });
 
 export const outputSchema = z.object({
-  receiver: addressSchema.describe(
-    "The address that will receive the output assets",
+  receiver: chainAddressSchema.describe(
+    "The CAIP-350 address that will receive the output assets",
   ),
-  asset: addressSchema.describe("The token/asset to be received as output"),
+  asset: chainAddressSchema.describe(
+    "The CAIP-350 address of the token/asset to be received as output",
+  ),
   amount: amountSchema
     .optional()
     .describe(
@@ -122,7 +142,7 @@ export const failureHandlingModeSchema = z
   );
 
 export const getQuoteRequestSchema = z.object({
-  user: addressSchema,
+  user: chainAddressSchema,
   intent: z.object({
     intentType: z.literal("oif-swap"),
     inputs: z.array(inputSchema),
@@ -191,8 +211,8 @@ export const postOrderResponseSchema = z.object({
 export const orderStatusSchema = z.nativeEnum(OrderStatus);
 
 export const assetAmountSchema = z.object({
-  asset: addressSchema.describe(
-    "The token/asset identifier, may include chain information",
+  asset: chainAddressSchema.describe(
+    "The token/asset identifier with chain information",
   ),
   amount: amountSchema
     .optional()
@@ -231,8 +251,8 @@ export const getOrderResponseSchema = z.object({
 });
 
 export const assetInfoSchema = z.object({
-  address: addressSchema.describe(
-    "Asset address in EIP-7930 interoperable format for cross-chain compatibility.\nAll addresses are formatted with the 0x prefix.",
+  address: chainAddressSchema.describe(
+    "Asset address in CAIP-350 format for cross-chain compatibility.",
   ),
   symbol: z
     .string()
@@ -245,11 +265,9 @@ export const assetInfoSchema = z.object({
 });
 
 export const networkAssetsSchema = z.object({
-  chain_id: z
-    .number()
-    .describe(
-      "Chain ID for the blockchain network (e.g., 1 for Ethereum, 137 for Polygon, 42161 for Arbitrum)",
-    ),
+  chain: chainSchema.describe(
+    "Chain identifier in CAIP-2 format (namespace:reference)",
+  ),
   assets: z
     .array(assetInfoSchema)
     .describe("Array of assets supported on this network"),
@@ -258,12 +276,15 @@ export const networkAssetsSchema = z.object({
 export const getAssetsResponseSchema = z.object({
   networks: z
     .record(
+      chainSchema.describe(
+        'Map where keys are CAIP-2 chain identifiers (e.g., "eip155:1", "eip155:137") and\nvalues are network asset configurations',
+      ),
       networkAssetsSchema.describe(
-        'Map where keys are chain IDs as strings (e.g., "1", "137", "42161") and\nvalues are network asset configurations',
+        'Map where keys are CAIP-2 chain identifiers (e.g., "eip155:1", "eip155:137") and\nvalues are network asset configurations',
       ),
     )
     .describe(
-      'Map where keys are chain IDs as strings (e.g., "1", "137", "42161") and\nvalues are network asset configurations',
+      'Map where keys are CAIP-2 chain identifiers (e.g., "eip155:1", "eip155:137") and\nvalues are network asset configurations',
     ),
 });
 

--- a/schemas/typescript/schemas.generated.ts
+++ b/schemas/typescript/schemas.generated.ts
@@ -5,21 +5,21 @@ import { PostOrderResponseStatus, OrderStatus, SettlementType } from "./types";
 export const chainSchema = z
   .string()
   .describe(
-    "Chain identifier following CAIP-2 standard (namespace:reference format).\nFor EVM chains, uses eip155 namespace with chain ID.",
+    "Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`).\nFor EVM chains, uses eip155 namespace with chain ID.",
   );
 
 export const nativeAddressSchema = z
   .string()
   .describe(
-    "Native blockchain address in its canonical format for the specified chain.\nFormat varies by chain namespace.",
+    "The address in its standard text representation for the specified chain.\nFormat varies by chain namespace.",
   );
 
 export const chainAddressSchema = z.object({
   chain: chainSchema.describe(
-    "The blockchain network identifier in CAIP-2 format (namespace:reference)",
+    "Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)",
   ),
   address: nativeAddressSchema.describe(
-    "The address in its native format for the specified chain",
+    "The address in its standard text representation for the specified chain",
   ),
 });
 
@@ -80,10 +80,10 @@ export const originSubmissionSchema = z.object({
 
 export const inputSchema = z.object({
   user: chainAddressSchema.describe(
-    "The CAIP-350 address of the user providing the input assets",
+    "The chain-specific address of the account providing the input assets",
   ),
   asset: chainAddressSchema.describe(
-    "The CAIP-350 address of the token/asset being provided as input",
+    "The chain-specific address of the token/asset being provided as input",
   ),
   amount: amountSchema
     .optional()
@@ -97,10 +97,10 @@ export const inputSchema = z.object({
 
 export const outputSchema = z.object({
   receiver: chainAddressSchema.describe(
-    "The CAIP-350 address that will receive the output assets",
+    "The chain-specific address of the account that will receive the output assets",
   ),
   asset: chainAddressSchema.describe(
-    "The CAIP-350 address of the token/asset to be received as output",
+    "The chain-specific address of the token/asset to be received as output",
   ),
   amount: amountSchema
     .optional()
@@ -252,7 +252,7 @@ export const getOrderResponseSchema = z.object({
 
 export const assetInfoSchema = z.object({
   address: chainAddressSchema.describe(
-    "Asset address in CAIP-350 format for cross-chain compatibility.",
+    "Chain-specific address for the asset",
   ),
   symbol: z
     .string()
@@ -266,7 +266,7 @@ export const assetInfoSchema = z.object({
 
 export const networkAssetsSchema = z.object({
   chain: chainSchema.describe(
-    "Chain identifier in CAIP-2 format (namespace:reference)",
+    "Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)",
   ),
   assets: z
     .array(assetInfoSchema)

--- a/schemas/typescript/schemas.generated.ts
+++ b/schemas/typescript/schemas.generated.ts
@@ -79,11 +79,12 @@ export const originSubmissionSchema = z.object({
 });
 
 export const inputSchema = z.object({
-  user: chainAddressSchema.describe(
-    "The chain-specific address of the account providing the input assets",
+  chain: chainSchema.describe("The chain where the input assets reside"),
+  user: nativeAddressSchema.describe(
+    "The address of the account providing the input assets",
   ),
-  asset: chainAddressSchema.describe(
-    "The chain-specific address of the token/asset being provided as input",
+  asset: nativeAddressSchema.describe(
+    "The address of the token/asset being provided as input",
   ),
   amount: amountSchema
     .optional()
@@ -96,11 +97,14 @@ export const inputSchema = z.object({
 });
 
 export const outputSchema = z.object({
-  receiver: chainAddressSchema.describe(
-    "The chain-specific address of the account that will receive the output assets",
+  chain: chainSchema.describe(
+    "The chain where the output assets will be delivered",
   ),
-  asset: chainAddressSchema.describe(
-    "The chain-specific address of the token/asset to be received as output",
+  receiver: nativeAddressSchema.describe(
+    "The address of the account that will receive the output assets",
+  ),
+  asset: nativeAddressSchema.describe(
+    "The address of the token/asset to be received as output",
   ),
   amount: amountSchema
     .optional()
@@ -251,9 +255,7 @@ export const getOrderResponseSchema = z.object({
 });
 
 export const assetInfoSchema = z.object({
-  address: chainAddressSchema.describe(
-    "Chain-specific address for the asset",
-  ),
+  address: chainAddressSchema.describe("Chain-specific address for the asset"),
   symbol: z
     .string()
     .describe(

--- a/schemas/typescript/schemas.generated.ts
+++ b/schemas/typescript/schemas.generated.ts
@@ -255,7 +255,9 @@ export const getOrderResponseSchema = z.object({
 });
 
 export const assetInfoSchema = z.object({
-  address: chainAddressSchema.describe("Chain-specific address for the asset"),
+  address: nativeAddressSchema.describe(
+    "Address for the asset in its standard text representation for the chain",
+  ),
   symbol: z
     .string()
     .describe(

--- a/schemas/typescript/types.ts
+++ b/schemas/typescript/types.ts
@@ -138,33 +138,41 @@ export interface OriginSubmission {
 /**
  * Available input from a user
  * @description Specifies assets that a user is willing to provide as input for a swap or transfer.
- *              Represents the "from" side of the transaction.
- * @example Exact-input quote (user has 4000 USDC):
+ *              Represents the "from" side of the transaction. The user and asset are always on the
+ *              same chain, so the chain is specified once at the top level.
+ * @example Exact-input quote (user has 4000 USDC on Ethereum):
  * {
- *   user: { chain: "eip155:1", address: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" },
- *   asset: { chain: "eip155:1", address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" }, // USDC on Ethereum
+ *   chain: "eip155:1",
+ *   user: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+ *   asset: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC on Ethereum
  *   amount: "4000000000", // Exactly 4000 USDC
  *   lock: { kind: "the-compact" }
  * }
  * @example Exact-output quote (amount undefined, will be quoted):
  * {
- *   user: { chain: "eip155:1", address: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" },
- *   asset: { chain: "eip155:1", address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" }, // USDC
+ *   chain: "eip155:1",
+ *   user: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+ *   asset: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC
  *   amount: undefined, // Provider will quote how much USDC needed
  *   lock: { kind: "the-compact" }
  * }
  */
 export interface Input {
+  /**
+   * Chain identifier
+   * @description The chain where the input assets reside
+   */
+  chain: Chain;
   /** 
    * User address 
-   * @description The chain-specific address of the account providing the input assets
+   * @description The address of the account providing the input assets
    */
-  user: ChainAddress;
+  user: NativeAddress;
   /** 
    * Asset address
-   * @description The chain-specific address of the token/asset being provided as input
+   * @description The address of the token/asset being provided as input
    */
-  asset: ChainAddress;
+  asset: NativeAddress;
   /** 
    * Amount available
    * @description For quote requests:
@@ -184,33 +192,41 @@ export interface Input {
 /**
  * Requested output for a receiver
  * @description Specifies the desired assets and destination for a swap or transfer.
- *              Represents the "to" side of the transaction.
+ *              Represents the "to" side of the transaction. The receiver and asset are always on the
+ *              same chain, so the chain is specified once at the top level.
  * @example Exact-input quote (amount undefined, will be quoted):
  * {
- *   receiver: { chain: "eip155:1", address: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8" },
- *   asset: { chain: "eip155:1", address: "0xdAC17F958D2ee523a2206206994597C13D831ec7" }, // USDT on Ethereum  
+ *   chain: "eip155:1",
+ *   receiver: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8",
+ *   asset: "0xdAC17F958D2ee523a2206206994597C13D831ec7", // USDT on Ethereum  
  *   amount: undefined, // Provider will quote how much USDT user receives
  *   calldata: "0x095ea7b3..."
  * }
  * @example Exact-output quote (user wants exactly 4000 USDT):
  * {
- *   receiver: { chain: "eip155:1", address: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8" },
- *   asset: { chain: "eip155:1", address: "0xdAC17F958D2ee523a2206206994597C13D831ec7" }, // USDT
+ *   chain: "eip155:1",
+ *   receiver: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8",
+ *   asset: "0xdAC17F958D2ee523a2206206994597C13D831ec7", // USDT
  *   amount: "4000000000", // Exactly 4000 USDT requested
  *   calldata: null
  * }
  */
 export interface Output {
+  /**
+   * Chain identifier
+   * @description The chain where the output assets will be delivered
+   */
+  chain: Chain;
   /** 
    * Receiver address
-   * @description The chain-specific address of the account that will receive the output assets
+   * @description The address of the account that will receive the output assets
    */
-  receiver: ChainAddress;
+  receiver: NativeAddress;
   /** 
    * Asset address
-   * @description The chain-specific address of the token/asset to be received as output
+   * @description The address of the token/asset to be received as output
    */
-  asset: ChainAddress;
+  asset: NativeAddress;
   /** 
    * Amount requested
    * @description For quote requests:

--- a/schemas/typescript/types.ts
+++ b/schemas/typescript/types.ts
@@ -572,13 +572,15 @@ export interface OifUserOpenIntentOrder {
   type: "oif-user-open-v0";
   /**
    * Open intent transaction to be executed by the settlement contract
-   * @description Encoded call with destination using CAIP-350 address format and raw calldata bytes
+   * @description Encoded call with destination address and raw calldata bytes
    */
   openIntentTx: {
-    /** Destination contract in CAIP-350 address format */
-    to: ChainAddress;
+    /** Chain where the transaction will be executed */
+    chain: Chain;
+    /** Destination contract address on the specified chain */
+    to: NativeAddress;
     /** Raw calldata bytes for the transaction */
-    data: Uint8Array; 
+    data: Uint8Array;
     /** Gas required for execution as a decimal string */
     gasRequired: string;
   };
@@ -956,21 +958,21 @@ export interface GetOrderResponse {
 /**
  * Asset metadata information
  * @description Metadata for a specific asset supported by a provider, including address,
- *              symbol, and decimal precision.
+ *              symbol, and decimal precision. The chain is determined by the parent NetworkAssets context.
  * @example
  * {
- *   address: { chain: "eip155:1", address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" }, // USDC on Ethereum
+ *   address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC on Ethereum
  *   symbol: "USDC",
  *   decimals: 6
  * }
  */
 export interface AssetInfo {
-  /** 
+  /**
    * Asset contract address
-   * @description Chain-specific address for the asset
-   * @example { chain: "eip155:1", address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" } - USDC on Ethereum
+   * @description Address for the asset in its standard text representation for the chain
+   * @example "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" - USDC on Ethereum
    */
-  address: ChainAddress;
+  address: NativeAddress;
   /** 
    * Human-readable asset identifier
    * @description Asset symbol for display purposes (e.g., "USDC", "WETH", "USDT")
@@ -996,7 +998,7 @@ export interface AssetInfo {
  *   chain: "eip155:1",
  *   assets: [
  *     {
- *       address: { chain: "eip155:1", address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" },
+ *       address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
  *       symbol: "USDC",
  *       decimals: 6
  *     }
@@ -1031,12 +1033,12 @@ export interface NetworkAssets {
  *       chain: "eip155:1",
  *       assets: [
  *         {
- *           address: { chain: "eip155:1", address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" },
+ *           address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
  *           symbol: "USDC",
  *           decimals: 6
  *         },
  *         {
- *           address: { chain: "eip155:1", address: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" },
+ *           address: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
  *           symbol: "WETH",
  *           decimals: 18
  *         }
@@ -1046,7 +1048,7 @@ export interface NetworkAssets {
  *       chain: "eip155:137",
  *       assets: [
  *         {
- *           address: { chain: "eip155:137", address: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359" },
+ *           address: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
  *           symbol: "USDC",
  *           decimals: 6
  *         }

--- a/schemas/typescript/types.ts
+++ b/schemas/typescript/types.ts
@@ -7,7 +7,7 @@
 
 /**
  * CAIP-2 chain identifier
- * @description Chain identifier following CAIP-2 standard (namespace:reference format).
+ * @description Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`).
  *              For EVM chains, uses eip155 namespace with chain ID.
  * @example "eip155:1" - Ethereum mainnet
  * @example "eip155:8453" - Base
@@ -19,7 +19,7 @@ export type Chain = string;
 
 /**
  * Native address format
- * @description Native blockchain address in its canonical format for the specified chain.
+ * @description The address in its standard text representation for the specified chain.
  *              Format varies by chain namespace.
  * @example "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" - EVM address
  * @example "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" - Solana address
@@ -48,14 +48,14 @@ export type NativeAddress = string;
 export interface ChainAddress {
   /**
    * CAIP-2 chain identifier
-   * @description The blockchain network identifier in CAIP-2 format (namespace:reference)
+   * @description Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
    * @example "eip155:1" - Ethereum mainnet
    * @example "eip155:8453" - Base
    */
   chain: Chain;
   /**
    * Native address
-   * @description The address in its native format for the specified chain
+   * @description The address in its standard text representation for the specified chain
    * @example "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
    */
   address: NativeAddress;
@@ -157,12 +157,12 @@ export interface OriginSubmission {
 export interface Input {
   /** 
    * User address 
-   * @description The CAIP-350 address of the user providing the input assets
+   * @description The chain-specific address of the account providing the input assets
    */
   user: ChainAddress;
   /** 
    * Asset address
-   * @description The CAIP-350 address of the token/asset being provided as input
+   * @description The chain-specific address of the token/asset being provided as input
    */
   asset: ChainAddress;
   /** 
@@ -203,12 +203,12 @@ export interface Input {
 export interface Output {
   /** 
    * Receiver address
-   * @description The CAIP-350 address that will receive the output assets
+   * @description The chain-specific address of the account that will receive the output assets
    */
   receiver: ChainAddress;
   /** 
    * Asset address
-   * @description The CAIP-350 address of the token/asset to be received as output
+   * @description The chain-specific address of the token/asset to be received as output
    */
   asset: ChainAddress;
   /** 
@@ -803,7 +803,7 @@ export enum OrderStatus {
  */
 export interface AssetAmount {
   /** 
-   * Asset address in CAIP-350 format
+   * Chain-specific address for the asset
    * @description The token/asset identifier with chain information
    */
   asset: ChainAddress;
@@ -944,7 +944,7 @@ export interface GetOrderResponse {
 export interface AssetInfo {
   /** 
    * Asset contract address
-   * @description Asset address in CAIP-350 format for cross-chain compatibility.
+   * @description Chain-specific address for the asset
    * @example { chain: "eip155:1", address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" } - USDC on Ethereum
    */
   address: ChainAddress;
@@ -983,7 +983,7 @@ export interface AssetInfo {
 export interface NetworkAssets {
   /** 
    * CAIP-2 chain identifier
-   * @description Chain identifier in CAIP-2 format (namespace:reference)
+   * @description Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
    * @example "eip155:1" - Ethereum mainnet
    * @example "eip155:137" - Polygon
    * @example "eip155:42161" - Arbitrum

--- a/schemas/typescript/types.ts
+++ b/schemas/typescript/types.ts
@@ -299,13 +299,15 @@ export type FailureHandlingMode =
  *   intent: {
  *     intentType: "oif-swap",
  *     inputs: [{ 
- *       user: { chain: "eip155:1", address: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8" },
- *       asset: { chain: "eip155:1", address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" }, // USDC
+ *       chain: "eip155:1",
+ *       user: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8",
+ *       asset: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC
  *       amount: "4000000000" // Exact: 4000 USDC
  *     }],
  *     outputs: [{ 
- *       receiver: { chain: "eip155:1", address: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8" },
- *       asset: { chain: "eip155:1", address: "0xdAC17F958D2ee523a2206206994597C13D831ec7" }, // USDT
+ *       chain: "eip155:1",
+ *       receiver: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8",
+ *       asset: "0xdAC17F958D2ee523a2206206994597C13D831ec7", // USDT
  *       amount: undefined // Provider will quote output amount
  *     }],
  *     swapType: "exact-input",
@@ -319,13 +321,15 @@ export type FailureHandlingMode =
  *   intent: {
  *     intentType: "oif-swap",
  *     inputs: [{
- *       user: { chain: "eip155:42161", address: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8" },
- *       asset: { chain: "eip155:42161", address: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831" }, // USDC on Arbitrum
+ *       chain: "eip155:42161",
+ *       user: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8",
+ *       asset: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831", // USDC on Arbitrum
  *       amount: undefined // Provider will quote input amount needed
  *     }],
  *     outputs: [{
- *       receiver: { chain: "eip155:42161", address: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8" },
- *       asset: { chain: "eip155:42161", address: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1" }, // WETH on Arbitrum
+ *       chain: "eip155:42161",
+ *       receiver: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8",
+ *       asset: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1", // WETH on Arbitrum
  *       amount: "2000000000000000000" // Exact: 2 WETH
  *     }],
  *     swapType: "exact-output",
@@ -554,9 +558,10 @@ export interface Oif3009Order {
  *   },
  *   checks: {
  *     allowances: [{
- *       token: { chain: "eip155:1", address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" },
- *       user: { chain: "eip155:1", address: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8" },
- *       spender: { chain: "eip155:1", address: "0x95ad61b0a150d79219dcf64e1e6cc01f0c0c8a4a" },
+ *       chain: "eip155:1",
+ *       token: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+ *       user: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8",
+ *       spender: "0x95ad61b0a150d79219dcf64e1e6cc01f0c0c8a4a",
  *       required: "1000000000"
  *     }]
  *   }
@@ -586,12 +591,14 @@ export interface OifUserOpenIntentOrder {
      * @description Each item asserts that `user` has at least `required` balance and allowance for `spender` on `token`.
      */
     allowances: Array<{
-      /** Token address in CAIP-350 format */
-      token: ChainAddress;
-      /** User address in CAIP-350 format */
-      user: ChainAddress;
-      /** Spender/settlement contract address in CAIP-350 format */
-      spender: ChainAddress;
+      /** The chain where the allowance check applies */
+      chain: Chain;
+      /** The address of the token requiring allowance */
+      token: NativeAddress;
+      /** The address of the user granting the allowance */
+      user: NativeAddress;
+      /** The address of the spender/settlement contract */
+      spender: NativeAddress;
       /** Required allowance amount as string-encoded integer */
       required: Amount;
     }>;

--- a/schemas/typescript/types.ts
+++ b/schemas/typescript/types.ts
@@ -6,15 +6,60 @@
 // ============ Common Types ============
 
 /**
- * EIP-7930 interoperable address format
- * @description Cross-chain compatible address format per EIP-7930 version 1 encoded format (0x0001 + chain ID + address) for 
- *              unambiguous cross-chain identification.
- * @pattern ^0x0001[a-fA-F0-9]+$
- * @example Cross-chain (Ethereum mainnet): "0x00010000010114D8DA6BF26964AF9D7EED9E03E53415D37AA96045"
- * @example Cross-chain (Polygon): "0x0001000001890314D8DA6BF26964AF9D7EED9E03E53415D37AA96045"
- * @see https://eips.ethereum.org/EIPS/eip-7930
+ * CAIP-2 chain identifier
+ * @description Chain identifier following CAIP-2 standard (namespace:reference format).
+ *              For EVM chains, uses eip155 namespace with chain ID.
+ * @example "eip155:1" - Ethereum mainnet
+ * @example "eip155:8453" - Base
+ * @example "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp" - Solana mainnet
+ * @example "bip122:000000000019d6689c085ae165831e93" - Bitcoin mainnet
+ * @see https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md
  */
-export type Address = string;
+export type Chain = string;
+
+/**
+ * Native address format
+ * @description Native blockchain address in its canonical format for the specified chain.
+ *              Format varies by chain namespace.
+ * @example "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" - EVM address
+ * @example "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" - Solana address
+ * @example "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4" - Bitcoin address
+ */
+export type NativeAddress = string;
+
+/**
+ * CAIP-350 chain-specific address
+ * @description Cross-chain compatible address format using CAIP-350 text identifiers.
+ *              Combines a CAIP-2 chain identifier with the native address format.
+ *              This is the canonical way to identify assets and accounts in the OIF API.
+ * @example USDC on Base:
+ * {
+ *   chain: "eip155:8453",
+ *   address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+ * }
+ * @example vitalik.eth on Ethereum mainnet:
+ * {
+ *   chain: "eip155:1",
+ *   address: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+ * }
+ * @see https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-350.md
+ * @see https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-10.md
+ */
+export interface ChainAddress {
+  /**
+   * CAIP-2 chain identifier
+   * @description The blockchain network identifier in CAIP-2 format (namespace:reference)
+   * @example "eip155:1" - Ethereum mainnet
+   * @example "eip155:8453" - Base
+   */
+  chain: Chain;
+  /**
+   * Native address
+   * @description The address in its native format for the specified chain
+   * @example "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+   */
+  address: NativeAddress;
+}
 
 /**
  * Token amount as string-encoded integer
@@ -96,15 +141,15 @@ export interface OriginSubmission {
  *              Represents the "from" side of the transaction.
  * @example Exact-input quote (user has 4000 USDC):
  * {
- *   user: "0x00010000010114D8DA6BF26964AF9D7EED9E03E53415D37AA96045", // Ethereum mainnet
- *   asset: "0x000100000101A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC on Ethereum
+ *   user: { chain: "eip155:1", address: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" },
+ *   asset: { chain: "eip155:1", address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" }, // USDC on Ethereum
  *   amount: "4000000000", // Exactly 4000 USDC
  *   lock: { kind: "the-compact" }
  * }
  * @example Exact-output quote (amount undefined, will be quoted):
  * {
- *   user: "0x00010000010114D8DA6BF26964AF9D7EED9E03E53415D37AA96045",
- *   asset: "0x000100000101A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC
+ *   user: { chain: "eip155:1", address: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" },
+ *   asset: { chain: "eip155:1", address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" }, // USDC
  *   amount: undefined, // Provider will quote how much USDC needed
  *   lock: { kind: "the-compact" }
  * }
@@ -112,14 +157,14 @@ export interface OriginSubmission {
 export interface Input {
   /** 
    * User address 
-   * @description The address providing the input assets
+   * @description The CAIP-350 address of the user providing the input assets
    */
-  user: Address;
+  user: ChainAddress;
   /** 
    * Asset address
-   * @description The token/asset being provided as input
+   * @description The CAIP-350 address of the token/asset being provided as input
    */
-  asset: Address;
+  asset: ChainAddress;
   /** 
    * Amount available
    * @description For quote requests:
@@ -142,15 +187,15 @@ export interface Input {
  *              Represents the "to" side of the transaction.
  * @example Exact-input quote (amount undefined, will be quoted):
  * {
- *   receiver: "0x000100000101742d35Cc6634C0532925a3b844Bc9e7595f0bEb8",
- *   asset: "0x000100000101dAC17F958D2ee523a2206206994597C13D831ec7", // USDT on Ethereum  
+ *   receiver: { chain: "eip155:1", address: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8" },
+ *   asset: { chain: "eip155:1", address: "0xdAC17F958D2ee523a2206206994597C13D831ec7" }, // USDT on Ethereum  
  *   amount: undefined, // Provider will quote how much USDT user receives
  *   calldata: "0x095ea7b3..."
  * }
  * @example Exact-output quote (user wants exactly 4000 USDT):
  * {
- *   receiver: "0x000100000101742d35Cc6634C0532925a3b844Bc9e7595f0bEb8",
- *   asset: "0x000100000101dAC17F958D2ee523a2206206994597C13D831ec7", // USDT
+ *   receiver: { chain: "eip155:1", address: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8" },
+ *   asset: { chain: "eip155:1", address: "0xdAC17F958D2ee523a2206206994597C13D831ec7" }, // USDT
  *   amount: "4000000000", // Exactly 4000 USDT requested
  *   calldata: null
  * }
@@ -158,14 +203,14 @@ export interface Input {
 export interface Output {
   /** 
    * Receiver address
-   * @description The address that will receive the output assets
+   * @description The CAIP-350 address that will receive the output assets
    */
-  receiver: Address;
+  receiver: ChainAddress;
   /** 
    * Asset address
-   * @description The token/asset to be received as output
+   * @description The CAIP-350 address of the token/asset to be received as output
    */
-  asset: Address;
+  asset: ChainAddress;
   /** 
    * Amount requested
    * @description For quote requests:
@@ -234,17 +279,17 @@ export type FailureHandlingMode =
  *              information for providers to calculate and return executable quotes.
  * @example Exact-input quote request (user has 4000 USDC, wants USDT quote):
  * {
- *   user: "0x000100000101742d35Cc6634C0532925a3b844Bc9e7595f0bEb8",
+ *   user: { chain: "eip155:1", address: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8" },
  *   intent: {
  *     intentType: "oif-swap",
  *     inputs: [{ 
- *       user: "0x000100000101742d35Cc6634C0532925a3b844Bc9e7595f0bEb8",
- *       asset: "0x000100000101A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC
+ *       user: { chain: "eip155:1", address: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8" },
+ *       asset: { chain: "eip155:1", address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" }, // USDC
  *       amount: "4000000000" // Exact: 4000 USDC
  *     }],
  *     outputs: [{ 
- *       receiver: "0x000100000101742d35Cc6634C0532925a3b844Bc9e7595f0bEb8",
- *       asset: "0x000100000101dAC17F958D2ee523a2206206994597C13D831ec7", // USDT
+ *       receiver: { chain: "eip155:1", address: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8" },
+ *       asset: { chain: "eip155:1", address: "0xdAC17F958D2ee523a2206206994597C13D831ec7" }, // USDT
  *       amount: undefined // Provider will quote output amount
  *     }],
  *     swapType: "exact-input",
@@ -254,17 +299,17 @@ export type FailureHandlingMode =
  * }
  * @example Exact-output quote request (user wants exactly 2 ETH, needs USDC quote):
  * {
- *   user: "0x00010000a4b1742d35Cc6634C0532925a3b844Bc9e7595f0bEb8", // Arbitrum
+ *   user: { chain: "eip155:42161", address: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8" }, // Arbitrum
  *   intent: {
  *     intentType: "oif-swap",
  *     inputs: [{
- *       user: "0x00010000a4b1742d35Cc6634C0532925a3b844Bc9e7595f0bEb8",
- *       asset: "0x00010000a4b1af48D7b320B0A4d3233e91B1c865238AE8", // USDC on Arbitrum
+ *       user: { chain: "eip155:42161", address: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8" },
+ *       asset: { chain: "eip155:42161", address: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831" }, // USDC on Arbitrum
  *       amount: undefined // Provider will quote input amount needed
  *     }],
  *     outputs: [{
- *       receiver: "0x00010000a4b1742d35Cc6634C0532925a3b844Bc9e7595f0bEb8",
- *       asset: "0x00010000a4b182e0B297B003493027903951655AF9d0e", // WETH on Arbitrum
+ *       receiver: { chain: "eip155:42161", address: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8" },
+ *       asset: { chain: "eip155:42161", address: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1" }, // WETH on Arbitrum
  *       amount: "2000000000000000000" // Exact: 2 WETH
  *     }],
  *     swapType: "exact-output",
@@ -275,7 +320,7 @@ export type FailureHandlingMode =
  */
 export interface GetQuoteRequest {
   /** User requesting the quote and recipient of refund inputs in case of failures */
-  user: Address;
+  user: ChainAddress;
 
   intent: {
     intentType: "oif-swap";
@@ -321,6 +366,7 @@ export type Order = OifEscrowOrder | OifResourceLockOrder | Oif3009Order | OifUs
  * @description Order that uses an escrow mechanism for asset custody during cross-chain transfers.
  *              Assets are held in escrow until conditions are met. Uses Permit2's PermitBatchWitnessTransferFrom
  *              for efficient batch transfers with additional witness data.
+ *              Note: The EIP-712 message payload uses native addresses (not CAIP-350) as required by the on-chain contracts.
  * @example
  * {
  *   type: "oif-escrow-v0",
@@ -330,13 +376,13 @@ export type Order = OifEscrowOrder | OifResourceLockOrder | Oif3009Order | OifUs
  *     primaryType: "PermitBatchWitnessTransferFrom",
  *     message: {
  *       permitted: [
- *         { token: "0x000100000101A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", amount: "1000000000" }
+ *         { token: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", amount: "1000000000" }
  *       ],
- *       spender: "0x00010000010195ad61b0a150d79219dcf64e1e6cc01f0c0c8a4a",
+ *       spender: "0x95ad61b0a150d79219dcf64e1e6cc01f0c0c8a4a",
  *       nonce: "123",
  *       deadline: 1700000000,
  *       witness: {
- *         recipient: "0x000100000101742d35Cc6634C0532925a3b844Bc9e7595f0bEb8",
+ *         recipient: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8",
  *         minAmountOut: "990000000"
  *       }
  *     }
@@ -361,6 +407,7 @@ export interface OifEscrowOrder {
  * @description Order that uses resource locking for asset control, typically with The Compact
  *              protocol for efficient batch operations and cross-chain transfers. Uses Compact
  *              signatures (e.g., BatchCompact) for gas-efficient multi-operation authorization.
+ *              Note: The EIP-712 message payload uses native addresses (not CAIP-350) as required by the on-chain contracts.
  * @example With Compact/BatchCompact signature:
  * {
  *   type: "oif-resource-lock-v0",
@@ -369,12 +416,12 @@ export interface OifEscrowOrder {
  *     domain: { name: "The Compact", version: "1", chainId: 1, verifyingContract: "0xabc..." },
  *     primaryType: "BatchCompact",
  *     message: {
- *       arbiter: "0x000100000101742d35Cc6634C0532925a3b844Bc9e7595f0bEb8",
- *       sponsor: "0x00010000010195ad61b0a150d79219dcf64e1e6cc01f0c0c8a4a",
+ *       arbiter: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8",
+ *       sponsor: "0x95ad61b0a150d79219dcf64e1e6cc01f0c0c8a4a",
  *       nonce: "123",
  *       expires: 1700000000,
  *       transfers: [
- *         { token: "0x000100000101A0b8...", amount: "1000000000", recipient: "0x..." }
+ *         { token: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", amount: "1000000000", recipient: "0x..." }
  *       ]
  *     }
  *   }
@@ -431,16 +478,17 @@ export interface OifResourceLockOrder {
  * EIP-3009 based order
  * @description Order using EIP-3009 Transfer With Authorization standard, commonly used by
  *              stablecoins like USDC. Includes metadata for nonce verification.
+ *              Note: The EIP-712 message payload uses native addresses (not CAIP-350) as required by the on-chain contracts.
  * @example
  * {
  *   type: "oif-3009-v0",
  *   payload: {
  *     signatureType: "eip712",
- *     domain: { name: "USD Coin", version: "2", chainId: 1, verifyingContract: "0xA0b8..." },
+ *     domain: { name: "USD Coin", version: "2", chainId: 1, verifyingContract: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" },
  *     primaryType: "TransferWithAuthorization",
  *     message: {
- *       from: "0x000100000101742d35Cc6634C0532925a3b844Bc9e7595f0bEb8",
- *       to: "0x00010000010195ad61b0a150d79219dcf64e1e6cc01f0c0c8a4a",
+ *       from: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8",
+ *       to: "0x95ad61b0a150d79219dcf64e1e6cc01f0c0c8a4a",
  *       value: "1000000000",
  *       validAfter: 0,
  *       validBefore: 1700000000,
@@ -484,15 +532,15 @@ export interface Oif3009Order {
  * {
  *   type: "oif-user-open-v0",
  *   openIntentTx: {
- *     to: "0x00010000010195ad61b0a150d79219dcf64e1e6cc01f0c0c8a4a",
+ *     to: { chain: "eip155:1", address: "0x95ad61b0a150d79219dcf64e1e6cc01f0c0c8a4a" },
  *     data: "0xaaaaaaaa....", // bytes in solidity
  *     gasRequired: "250000"
  *   },
  *   checks: {
  *     allowances: [{
- *       token: "0x000100000101A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
- *       user: "0x000100000101742d35Cc6634C0532925a3b844Bc9e7595f0bEb8",
- *       spender: "0x00010000010195ad61b0a150d79219dcf64e1e6cc01f0c0c8a4a",
+ *       token: { chain: "eip155:1", address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" },
+ *       user: { chain: "eip155:1", address: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8" },
+ *       spender: { chain: "eip155:1", address: "0x95ad61b0a150d79219dcf64e1e6cc01f0c0c8a4a" },
  *       required: "1000000000"
  *     }]
  *   }
@@ -503,11 +551,11 @@ export interface OifUserOpenIntentOrder {
   type: "oif-user-open-v0";
   /**
    * Open intent transaction to be executed by the settlement contract
-   * @description Encoded call with destination using EIP-7930 address format and raw calldata bytes
+   * @description Encoded call with destination using CAIP-350 address format and raw calldata bytes
    */
   openIntentTx: {
-    /** Destination contract in EIP-7930 address format */
-    to: Address;
+    /** Destination contract in CAIP-350 address format */
+    to: ChainAddress;
     /** Raw calldata bytes for the transaction */
     data: Uint8Array; 
     /** Gas required for execution as a decimal string */
@@ -519,15 +567,15 @@ export interface OifUserOpenIntentOrder {
   checks: {
     /**
      * Required allowances and balances
-     * @description Each item asserts that `user` has at least `required` balance andallowance for `spender` on `token`.
+     * @description Each item asserts that `user` has at least `required` balance and allowance for `spender` on `token`.
      */
     allowances: Array<{
-      /** Token address in EIP-7930 format */
-      token: Address;
-      /** User address in EIP-7930 format */
-      user: Address;
-      /** Spender/settlement contract address in EIP-7930 format */
-      spender: Address;
+      /** Token address in CAIP-350 format */
+      token: ChainAddress;
+      /** User address in CAIP-350 format */
+      user: ChainAddress;
+      /** Spender/settlement contract address in CAIP-350 format */
+      spender: ChainAddress;
       /** Required allowance amount as string-encoded integer */
       required: Amount;
     }>;
@@ -745,20 +793,20 @@ export enum OrderStatus {
 
 /**
  * Asset amount representation
- * @description Combines an asset identifier with an amount, using EIP-7930 addresses for
+ * @description Combines an asset identifier with an amount, using CAIP-350 addresses for
  *              cross-chain compatibility.
  * @example Cross-chain:
  * {
- *   asset: "0x00010000018903A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC on Polygon (chain 137 = 0x89 in hex, 0x8903 in EIP-7930)
+ *   asset: { chain: "eip155:137", address: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359" }, // USDC on Polygon
  *   amount: "500000000" // 500 USDC (6 decimals)
  * }
  */
 export interface AssetAmount {
   /** 
-   * Asset address in EIP-7930 interoperable format
-   * @description The token/asset identifier, may include chain information
+   * Asset address in CAIP-350 format
+   * @description The token/asset identifier with chain information
    */
-  asset: Address;
+  asset: ChainAddress;
   /** 
    * Amount as a string-encoded integer
    * @description Token amount in smallest unit (wei, satoshi, etc.)
@@ -841,12 +889,12 @@ export interface GetOrderRequest {
  *   createdAt: 1699900000,
  *   updatedAt: 1699900100,
  *   quoteId: "quote-123-abc",
- *   inputAmount: [{
- *     asset: "0x000100000101742d35Cc6634C0532925a3b844Bc9e7595f0bEb8",
+ *   inputAmounts: [{
+ *     asset: { chain: "eip155:1", address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" },
  *     amount: "1000000000"
  *   }],
- *   outputAmount: [{
- *     asset: "0x000100000101742d35Cc6634C0532925a3b844Bc9e7595f0bEb9",
+ *   outputAmounts: [{
+ *     asset: { chain: "eip155:1", address: "0xdAC17F958D2ee523a2206206994597C13D831ec7" },
  *     amount: "500000000000000000"
  *   }],
  *   settlement: {
@@ -888,7 +936,7 @@ export interface GetOrderResponse {
  *              symbol, and decimal precision.
  * @example
  * {
- *   address: "0x000100000101A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC on Ethereum (EIP-7930 format)
+ *   address: { chain: "eip155:1", address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" }, // USDC on Ethereum
  *   symbol: "USDC",
  *   decimals: 6
  * }
@@ -896,11 +944,10 @@ export interface GetOrderResponse {
 export interface AssetInfo {
   /** 
    * Asset contract address
-   * @description Asset address in EIP-7930 interoperable format for cross-chain compatibility.
-   *              All addresses are formatted with the 0x prefix.
-   * @example "0x000100000101A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" - USDC on Ethereum
+   * @description Asset address in CAIP-350 format for cross-chain compatibility.
+   * @example { chain: "eip155:1", address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" } - USDC on Ethereum
    */
-  address: Address;
+  address: ChainAddress;
   /** 
    * Human-readable asset identifier
    * @description Asset symbol for display purposes (e.g., "USDC", "WETH", "USDT")
@@ -920,13 +967,13 @@ export interface AssetInfo {
 /**
  * Network asset configuration
  * @description Represents asset support for a single blockchain network.
- *              Contains the chain identifier and list of supported assets.
+ *              Contains the CAIP-2 chain identifier and list of supported assets.
  * @example
  * {
- *   chain_id: 1,
+ *   chain: "eip155:1",
  *   assets: [
  *     {
- *       address: "0x000100000101A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+ *       address: { chain: "eip155:1", address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" },
  *       symbol: "USDC",
  *       decimals: 6
  *     }
@@ -935,13 +982,13 @@ export interface AssetInfo {
  */
 export interface NetworkAssets {
   /** 
-   * Blockchain network identifier
-   * @description Chain ID for the blockchain network (e.g., 1 for Ethereum, 137 for Polygon, 42161 for Arbitrum)
-   * @example 1 - Ethereum mainnet
-   * @example 137 - Polygon
-   * @example 42161 - Arbitrum
+   * CAIP-2 chain identifier
+   * @description Chain identifier in CAIP-2 format (namespace:reference)
+   * @example "eip155:1" - Ethereum mainnet
+   * @example "eip155:137" - Polygon
+   * @example "eip155:42161" - Arbitrum
    */
-  chain_id: number;
+  chain: Chain;
   /** 
    * List of supported assets
    * @description Array of assets supported on this network
@@ -957,26 +1004,26 @@ export interface NetworkAssets {
  * @example
  * {
  *   networks: {
- *     "1": {
- *       chain_id: 1,
+ *     "eip155:1": {
+ *       chain: "eip155:1",
  *       assets: [
  *         {
- *           address: "0x000100000101A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+ *           address: { chain: "eip155:1", address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" },
  *           symbol: "USDC",
  *           decimals: 6
  *         },
  *         {
- *           address: "0x0001000001010303030303030303030303030303030303030303030303030303",
+ *           address: { chain: "eip155:1", address: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" },
  *           symbol: "WETH",
  *           decimals: 18
  *         }
  *       ]
  *     },
- *     "137": {
- *       chain_id: 137,
+ *     "eip155:137": {
+ *       chain: "eip155:137",
  *       assets: [
  *         {
- *           address: "0x00010000018903A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+ *           address: { chain: "eip155:137", address: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359" },
  *           symbol: "USDC",
  *           decimals: 6
  *         }
@@ -987,9 +1034,9 @@ export interface NetworkAssets {
  */
 export interface GetAssetsResponse {
   /** 
-   * Map of chain ID to network configuration
-   * @description Map where keys are chain IDs as strings (e.g., "1", "137", "42161") and
+   * Map of CAIP-2 chain identifier to network configuration
+   * @description Map where keys are CAIP-2 chain identifiers (e.g., "eip155:1", "eip155:137") and
    *              values are network asset configurations
    */
-  networks: Record<string, NetworkAssets>;
+  networks: Record<Chain, NetworkAssets>;
 }

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -23,7 +23,7 @@ const registry = new OpenAPIRegistry();
 const oifUserOpenIntentOrderSchema = z.object({
   type: z.literal("oif-user-open-v0"),
   openIntentTx: z.object({
-    to: schemas.addressSchema,
+    to: schemas.chainAddressSchema.describe("Destination contract in CAIP-350 address format"),
     // Represent bytes as an array of numbers (0-255)
     data: z.array(z.number()).describe("Raw calldata bytes for the transaction"),
     gasRequired: z.string(),
@@ -31,9 +31,9 @@ const oifUserOpenIntentOrderSchema = z.object({
   checks: z.object({
     allowances: z.array(
       z.object({
-        token: schemas.addressSchema,
-        user: schemas.addressSchema,
-        spender: schemas.addressSchema,
+        token: schemas.chainAddressSchema.describe("Token address in CAIP-350 format"),
+        user: schemas.chainAddressSchema.describe("User address in CAIP-350 format"),
+        spender: schemas.chainAddressSchema.describe("Spender/settlement contract address in CAIP-350 format"),
         required: schemas.amountSchema,
       })
     ),
@@ -90,7 +90,9 @@ const postOrderRequestSchema = z.object({
 });
 
 // Register all schemas as components
-registry.register("Address", schemas.addressSchema);
+registry.register("Chain", schemas.chainSchema);
+registry.register("NativeAddress", schemas.nativeAddressSchema);
+registry.register("ChainAddress", schemas.chainAddressSchema);
 registry.register("Amount", schemas.amountSchema);
 registry.register("SwapType", schemas.swapTypeSchema);
 registry.register("AssetLockReference", schemas.assetLockReferenceSchema);

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -31,9 +31,10 @@ const oifUserOpenIntentOrderSchema = z.object({
   checks: z.object({
     allowances: z.array(
       z.object({
-        token: schemas.chainAddressSchema.describe("Token address in CAIP-350 format"),
-        user: schemas.chainAddressSchema.describe("User address in CAIP-350 format"),
-        spender: schemas.chainAddressSchema.describe("Spender/settlement contract address in CAIP-350 format"),
+        chain: schemas.chainSchema.describe("The chain where the allowance check applies"),
+        token: schemas.nativeAddressSchema.describe("The address of the token requiring allowance"),
+        user: schemas.nativeAddressSchema.describe("The address of the user granting the allowance"),
+        spender: schemas.nativeAddressSchema.describe("The address of the spender/settlement contract"),
         required: schemas.amountSchema,
       })
     ),

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -23,7 +23,8 @@ const registry = new OpenAPIRegistry();
 const oifUserOpenIntentOrderSchema = z.object({
   type: z.literal("oif-user-open-v0"),
   openIntentTx: z.object({
-    to: schemas.chainAddressSchema.describe("Destination contract in CAIP-350 address format"),
+    chain: schemas.chainSchema.describe("Chain where the transaction will be executed"),
+    to: schemas.nativeAddressSchema.describe("Destination contract address on the specified chain"),
     // Represent bytes as an array of numbers (0-255)
     data: z.array(z.number()).describe("Raw calldata bytes for the transaction"),
     gasRequired: z.string(),

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -753,19 +753,12 @@ components:
             openIntentTx:
               type: object
               properties:
+                chain:
+                  type: string
+                  description: Chain where the transaction will be executed
                 to:
-                  type: object
-                  properties:
-                    chain:
-                      type: string
-                      description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                    address:
-                      type: string
-                      description: The address in its standard text representation for the specified chain
-                  required:
-                    - chain
-                    - address
-                  description: Destination contract in CAIP-350 address format
+                  type: string
+                  description: Destination contract address on the specified chain
                 data:
                   type: array
                   items:
@@ -774,6 +767,7 @@ components:
                 gasRequired:
                   type: string
               required:
+                - chain
                 - to
                 - data
                 - gasRequired
@@ -979,19 +973,12 @@ components:
                 openIntentTx:
                   type: object
                   properties:
+                    chain:
+                      type: string
+                      description: Chain where the transaction will be executed
                     to:
-                      type: object
-                      properties:
-                        chain:
-                          type: string
-                          description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                        address:
-                          type: string
-                          description: The address in its standard text representation for the specified chain
-                      required:
-                        - chain
-                        - address
-                      description: Destination contract in CAIP-350 address format
+                      type: string
+                      description: Destination contract address on the specified chain
                     data:
                       type: array
                       items:
@@ -1000,6 +987,7 @@ components:
                     gasRequired:
                       type: string
                   required:
+                    - chain
                     - to
                     - data
                     - gasRequired
@@ -1420,19 +1408,12 @@ components:
                       openIntentTx:
                         type: object
                         properties:
+                          chain:
+                            type: string
+                            description: Chain where the transaction will be executed
                           to:
-                            type: object
-                            properties:
-                              chain:
-                                type: string
-                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                              address:
-                                type: string
-                                description: The address in its standard text representation for the specified chain
-                            required:
-                              - chain
-                              - address
-                            description: Destination contract in CAIP-350 address format
+                            type: string
+                            description: Destination contract address on the specified chain
                           data:
                             type: array
                             items:
@@ -1441,6 +1422,7 @@ components:
                           gasRequired:
                             type: string
                         required:
+                          - chain
                           - to
                           - data
                           - gasRequired
@@ -1771,19 +1753,12 @@ components:
                 openIntentTx:
                   type: object
                   properties:
+                    chain:
+                      type: string
+                      description: Chain where the transaction will be executed
                     to:
-                      type: object
-                      properties:
-                        chain:
-                          type: string
-                          description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                        address:
-                          type: string
-                          description: The address in its standard text representation for the specified chain
-                      required:
-                        - chain
-                        - address
-                      description: Destination contract in CAIP-350 address format
+                      type: string
+                      description: Destination contract address on the specified chain
                     data:
                       type: array
                       items:
@@ -1792,6 +1767,7 @@ components:
                     gasRequired:
                       type: string
                   required:
+                    - chain
                     - to
                     - data
                     - gasRequired
@@ -2473,19 +2449,12 @@ paths:
                                 openIntentTx:
                                   type: object
                                   properties:
+                                    chain:
+                                      type: string
+                                      description: Chain where the transaction will be executed
                                     to:
-                                      type: object
-                                      properties:
-                                        chain:
-                                          type: string
-                                          description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                                        address:
-                                          type: string
-                                          description: The address in its standard text representation for the specified chain
-                                      required:
-                                        - chain
-                                        - address
-                                      description: Destination contract in CAIP-350 address format
+                                      type: string
+                                      description: Destination contract address on the specified chain
                                     data:
                                       type: array
                                       items:
@@ -2494,6 +2463,7 @@ paths:
                                     gasRequired:
                                       type: string
                                   required:
+                                    - chain
                                     - to
                                     - data
                                     - gasRequired
@@ -2837,19 +2807,12 @@ paths:
                         openIntentTx:
                           type: object
                           properties:
+                            chain:
+                              type: string
+                              description: Chain where the transaction will be executed
                             to:
-                              type: object
-                              properties:
-                                chain:
-                                  type: string
-                                  description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                                address:
-                                  type: string
-                                  description: The address in its standard text representation for the specified chain
-                              required:
-                                - chain
-                                - address
-                              description: Destination contract in CAIP-350 address format
+                              type: string
+                              description: Destination contract address on the specified chain
                             data:
                               type: array
                               items:
@@ -2858,6 +2821,7 @@ paths:
                             gasRequired:
                               type: string
                           required:
+                            - chain
                             - to
                             - data
                             - gasRequired

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -121,32 +121,15 @@ components:
     Input:
       type: object
       properties:
+        chain:
+          type: string
+          description: The chain where the input assets reside
         user:
-          type: object
-          properties:
-            chain:
-              type: string
-              description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-            address:
-              type: string
-              description: The address in its standard text representation for the specified chain
-          required:
-            - chain
-            - address
-          description: The chain-specific address of the account providing the input assets
+          type: string
+          description: The address of the account providing the input assets
         asset:
-          type: object
-          properties:
-            chain:
-              type: string
-              description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-            address:
-              type: string
-              description: The address in its standard text representation for the specified chain
-          required:
-            - chain
-            - address
-          description: The chain-specific address of the token/asset being provided as input
+          type: string
+          description: The address of the token/asset being provided as input
         amount:
           type: string
           pattern: ^[0-9]+$
@@ -180,37 +163,21 @@ components:
             - kind
           description: Locking mechanism to use for securing the input assets
       required:
+        - chain
         - user
         - asset
     Output:
       type: object
       properties:
+        chain:
+          type: string
+          description: The chain where the output assets will be delivered
         receiver:
-          type: object
-          properties:
-            chain:
-              type: string
-              description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-            address:
-              type: string
-              description: The address in its standard text representation for the specified chain
-          required:
-            - chain
-            - address
-          description: The chain-specific address of the account that will receive the output assets
+          type: string
+          description: The address of the account that will receive the output assets
         asset:
-          type: object
-          properties:
-            chain:
-              type: string
-              description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-            address:
-              type: string
-              description: The address in its standard text representation for the specified chain
-          required:
-            - chain
-            - address
-          description: The chain-specific address of the token/asset to be received as output
+          type: string
+          description: The address of the token/asset to be received as output
         amount:
           type: string
           pattern: ^[0-9]+$
@@ -225,6 +192,7 @@ components:
             Encoded function call to be executed when delivering the output,
             enabling composability with other protocols
       required:
+        - chain
         - receiver
         - asset
     QuotePreference:
@@ -290,32 +258,15 @@ components:
               items:
                 type: object
                 properties:
+                  chain:
+                    type: string
+                    description: The chain where the input assets reside
                   user:
-                    type: object
-                    properties:
-                      chain:
-                        type: string
-                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                      address:
-                        type: string
-                        description: The address in its standard text representation for the specified chain
-                    required:
-                      - chain
-                      - address
-                    description: The chain-specific address of the account providing the input assets
+                    type: string
+                    description: The address of the account providing the input assets
                   asset:
-                    type: object
-                    properties:
-                      chain:
-                        type: string
-                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                      address:
-                        type: string
-                        description: The address in its standard text representation for the specified chain
-                    required:
-                      - chain
-                      - address
-                    description: The chain-specific address of the token/asset being provided as input
+                    type: string
+                    description: The address of the token/asset being provided as input
                   amount:
                     type: string
                     pattern: ^[0-9]+$
@@ -349,6 +300,7 @@ components:
                       - kind
                     description: Locking mechanism to use for securing the input assets
                 required:
+                  - chain
                   - user
                   - asset
             outputs:
@@ -356,32 +308,15 @@ components:
               items:
                 type: object
                 properties:
+                  chain:
+                    type: string
+                    description: The chain where the output assets will be delivered
                   receiver:
-                    type: object
-                    properties:
-                      chain:
-                        type: string
-                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                      address:
-                        type: string
-                        description: The address in its standard text representation for the specified chain
-                    required:
-                      - chain
-                      - address
-                    description: The chain-specific address of the account that will receive the output assets
+                    type: string
+                    description: The address of the account that will receive the output assets
                   asset:
-                    type: object
-                    properties:
-                      chain:
-                        type: string
-                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                      address:
-                        type: string
-                        description: The address in its standard text representation for the specified chain
-                    required:
-                      - chain
-                      - address
-                    description: The chain-specific address of the token/asset to be received as output
+                    type: string
+                    description: The address of the token/asset to be received as output
                   amount:
                     type: string
                     pattern: ^[0-9]+$
@@ -396,6 +331,7 @@ components:
                       Encoded function call to be executed when delivering the output,
                       enabling composability with other protocols
                 required:
+                  - chain
                   - receiver
                   - asset
             swapType:
@@ -1174,32 +1110,15 @@ components:
               items:
                 type: object
                 properties:
+                  chain:
+                    type: string
+                    description: The chain where the input assets reside
                   user:
-                    type: object
-                    properties:
-                      chain:
-                        type: string
-                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                      address:
-                        type: string
-                        description: The address in its standard text representation for the specified chain
-                    required:
-                      - chain
-                      - address
-                    description: The chain-specific address of the account providing the input assets
+                    type: string
+                    description: The address of the account providing the input assets
                   asset:
-                    type: object
-                    properties:
-                      chain:
-                        type: string
-                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                      address:
-                        type: string
-                        description: The address in its standard text representation for the specified chain
-                    required:
-                      - chain
-                      - address
-                    description: The chain-specific address of the token/asset being provided as input
+                    type: string
+                    description: The address of the token/asset being provided as input
                   amount:
                     type: string
                     pattern: ^[0-9]+$
@@ -1233,6 +1152,7 @@ components:
                       - kind
                     description: Locking mechanism to use for securing the input assets
                 required:
+                  - chain
                   - user
                   - asset
             outputs:
@@ -1240,32 +1160,15 @@ components:
               items:
                 type: object
                 properties:
+                  chain:
+                    type: string
+                    description: The chain where the output assets will be delivered
                   receiver:
-                    type: object
-                    properties:
-                      chain:
-                        type: string
-                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                      address:
-                        type: string
-                        description: The address in its standard text representation for the specified chain
-                    required:
-                      - chain
-                      - address
-                    description: The chain-specific address of the account that will receive the output assets
+                    type: string
+                    description: The address of the account that will receive the output assets
                   asset:
-                    type: object
-                    properties:
-                      chain:
-                        type: string
-                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                      address:
-                        type: string
-                        description: The address in its standard text representation for the specified chain
-                    required:
-                      - chain
-                      - address
-                    description: The chain-specific address of the token/asset to be received as output
+                    type: string
+                    description: The address of the token/asset to be received as output
                   amount:
                     type: string
                     pattern: ^[0-9]+$
@@ -1280,6 +1183,7 @@ components:
                       Encoded function call to be executed when delivering the output,
                       enabling composability with other protocols
                 required:
+                  - chain
                   - receiver
                   - asset
           required:
@@ -1321,32 +1225,15 @@ components:
           items:
             type: object
             properties:
+              chain:
+                type: string
+                description: The chain where the input assets reside
               user:
-                type: object
-                properties:
-                  chain:
-                    type: string
-                    description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                  address:
-                    type: string
-                    description: The address in its standard text representation for the specified chain
-                required:
-                  - chain
-                  - address
-                description: The chain-specific address of the account providing the input assets
+                type: string
+                description: The address of the account providing the input assets
               asset:
-                type: object
-                properties:
-                  chain:
-                    type: string
-                    description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                  address:
-                    type: string
-                    description: The address in its standard text representation for the specified chain
-                required:
-                  - chain
-                  - address
-                description: The chain-specific address of the token/asset being provided as input
+                type: string
+                description: The address of the token/asset being provided as input
               amount:
                 type: string
                 pattern: ^[0-9]+$
@@ -1380,6 +1267,7 @@ components:
                   - kind
                 description: Locking mechanism to use for securing the input assets
             required:
+              - chain
               - user
               - asset
         outputs:
@@ -1387,32 +1275,15 @@ components:
           items:
             type: object
             properties:
+              chain:
+                type: string
+                description: The chain where the output assets will be delivered
               receiver:
-                type: object
-                properties:
-                  chain:
-                    type: string
-                    description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                  address:
-                    type: string
-                    description: The address in its standard text representation for the specified chain
-                required:
-                  - chain
-                  - address
-                description: The chain-specific address of the account that will receive the output assets
+                type: string
+                description: The address of the account that will receive the output assets
               asset:
-                type: object
-                properties:
-                  chain:
-                    type: string
-                    description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                  address:
-                    type: string
-                    description: The address in its standard text representation for the specified chain
-                required:
-                  - chain
-                  - address
-                description: The chain-specific address of the token/asset to be received as output
+                type: string
+                description: The address of the token/asset to be received as output
               amount:
                 type: string
                 pattern: ^[0-9]+$
@@ -1427,6 +1298,7 @@ components:
                   Encoded function call to be executed when delivering the output,
                   enabling composability with other protocols
             required:
+              - chain
               - receiver
               - asset
       required:
@@ -1705,32 +1577,15 @@ components:
                     items:
                       type: object
                       properties:
+                        chain:
+                          type: string
+                          description: The chain where the input assets reside
                         user:
-                          type: object
-                          properties:
-                            chain:
-                              type: string
-                              description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                            address:
-                              type: string
-                              description: The address in its standard text representation for the specified chain
-                          required:
-                            - chain
-                            - address
-                          description: The chain-specific address of the account providing the input assets
+                          type: string
+                          description: The address of the account providing the input assets
                         asset:
-                          type: object
-                          properties:
-                            chain:
-                              type: string
-                              description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                            address:
-                              type: string
-                              description: The address in its standard text representation for the specified chain
-                          required:
-                            - chain
-                            - address
-                          description: The chain-specific address of the token/asset being provided as input
+                          type: string
+                          description: The address of the token/asset being provided as input
                         amount:
                           type: string
                           pattern: ^[0-9]+$
@@ -1764,6 +1619,7 @@ components:
                             - kind
                           description: Locking mechanism to use for securing the input assets
                       required:
+                        - chain
                         - user
                         - asset
                   outputs:
@@ -1771,32 +1627,15 @@ components:
                     items:
                       type: object
                       properties:
+                        chain:
+                          type: string
+                          description: The chain where the output assets will be delivered
                         receiver:
-                          type: object
-                          properties:
-                            chain:
-                              type: string
-                              description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                            address:
-                              type: string
-                              description: The address in its standard text representation for the specified chain
-                          required:
-                            - chain
-                            - address
-                          description: The chain-specific address of the account that will receive the output assets
+                          type: string
+                          description: The address of the account that will receive the output assets
                         asset:
-                          type: object
-                          properties:
-                            chain:
-                              type: string
-                              description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                            address:
-                              type: string
-                              description: The address in its standard text representation for the specified chain
-                          required:
-                            - chain
-                            - address
-                          description: The chain-specific address of the token/asset to be received as output
+                          type: string
+                          description: The address of the token/asset to be received as output
                         amount:
                           type: string
                           pattern: ^[0-9]+$
@@ -1811,6 +1650,7 @@ components:
                             Encoded function call to be executed when delivering the output,
                             enabling composability with other protocols
                       required:
+                        - chain
                         - receiver
                         - asset
                 required:
@@ -2381,32 +2221,15 @@ paths:
                       items:
                         type: object
                         properties:
+                          chain:
+                            type: string
+                            description: The chain where the input assets reside
                           user:
-                            type: object
-                            properties:
-                              chain:
-                                type: string
-                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                              address:
-                                type: string
-                                description: The address in its standard text representation for the specified chain
-                            required:
-                              - chain
-                              - address
-                            description: The chain-specific address of the account providing the input assets
+                            type: string
+                            description: The address of the account providing the input assets
                           asset:
-                            type: object
-                            properties:
-                              chain:
-                                type: string
-                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                              address:
-                                type: string
-                                description: The address in its standard text representation for the specified chain
-                            required:
-                              - chain
-                              - address
-                            description: The chain-specific address of the token/asset being provided as input
+                            type: string
+                            description: The address of the token/asset being provided as input
                           amount:
                             type: string
                             pattern: ^[0-9]+$
@@ -2440,6 +2263,7 @@ paths:
                               - kind
                             description: Locking mechanism to use for securing the input assets
                         required:
+                          - chain
                           - user
                           - asset
                     outputs:
@@ -2447,32 +2271,15 @@ paths:
                       items:
                         type: object
                         properties:
+                          chain:
+                            type: string
+                            description: The chain where the output assets will be delivered
                           receiver:
-                            type: object
-                            properties:
-                              chain:
-                                type: string
-                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                              address:
-                                type: string
-                                description: The address in its standard text representation for the specified chain
-                            required:
-                              - chain
-                              - address
-                            description: The chain-specific address of the account that will receive the output assets
+                            type: string
+                            description: The address of the account that will receive the output assets
                           asset:
-                            type: object
-                            properties:
-                              chain:
-                                type: string
-                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                              address:
-                                type: string
-                                description: The address in its standard text representation for the specified chain
-                            required:
-                              - chain
-                              - address
-                            description: The chain-specific address of the token/asset to be received as output
+                            type: string
+                            description: The address of the token/asset to be received as output
                           amount:
                             type: string
                             pattern: ^[0-9]+$
@@ -2487,6 +2294,7 @@ paths:
                               Encoded function call to be executed when delivering the output,
                               enabling composability with other protocols
                         required:
+                          - chain
                           - receiver
                           - asset
                     swapType:
@@ -2874,32 +2682,15 @@ paths:
                               items:
                                 type: object
                                 properties:
+                                  chain:
+                                    type: string
+                                    description: The chain where the input assets reside
                                   user:
-                                    type: object
-                                    properties:
-                                      chain:
-                                        type: string
-                                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                                      address:
-                                        type: string
-                                        description: The address in its standard text representation for the specified chain
-                                    required:
-                                      - chain
-                                      - address
-                                    description: The chain-specific address of the account providing the input assets
+                                    type: string
+                                    description: The address of the account providing the input assets
                                   asset:
-                                    type: object
-                                    properties:
-                                      chain:
-                                        type: string
-                                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                                      address:
-                                        type: string
-                                        description: The address in its standard text representation for the specified chain
-                                    required:
-                                      - chain
-                                      - address
-                                    description: The chain-specific address of the token/asset being provided as input
+                                    type: string
+                                    description: The address of the token/asset being provided as input
                                   amount:
                                     type: string
                                     pattern: ^[0-9]+$
@@ -2933,6 +2724,7 @@ paths:
                                       - kind
                                     description: Locking mechanism to use for securing the input assets
                                 required:
+                                  - chain
                                   - user
                                   - asset
                             outputs:
@@ -2940,32 +2732,15 @@ paths:
                               items:
                                 type: object
                                 properties:
+                                  chain:
+                                    type: string
+                                    description: The chain where the output assets will be delivered
                                   receiver:
-                                    type: object
-                                    properties:
-                                      chain:
-                                        type: string
-                                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                                      address:
-                                        type: string
-                                        description: The address in its standard text representation for the specified chain
-                                    required:
-                                      - chain
-                                      - address
-                                    description: The chain-specific address of the account that will receive the output assets
+                                    type: string
+                                    description: The address of the account that will receive the output assets
                                   asset:
-                                    type: object
-                                    properties:
-                                      chain:
-                                        type: string
-                                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                                      address:
-                                        type: string
-                                        description: The address in its standard text representation for the specified chain
-                                    required:
-                                      - chain
-                                      - address
-                                    description: The chain-specific address of the token/asset to be received as output
+                                    type: string
+                                    description: The address of the token/asset to be received as output
                                   amount:
                                     type: string
                                     pattern: ^[0-9]+$
@@ -2980,6 +2755,7 @@ paths:
                                       Encoded function call to be executed when delivering the output,
                                       enabling composability with other protocols
                                 required:
+                                  - chain
                                   - receiver
                                   - asset
                           required:

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -14,12 +14,28 @@ tags:
     description: Order management
 components:
   schemas:
-    Address:
+    Chain:
       type: string
-      pattern: ^0x0001[a-fA-F0-9]+$
       description: |-
-        Cross-chain compatible address format per EIP-7930 version 1 encoded format (0x0001 + chain ID + address) for
-        unambiguous cross-chain identification.
+        Chain identifier following CAIP-2 standard (namespace:reference format).
+        For EVM chains, uses eip155 namespace with chain ID.
+    NativeAddress:
+      type: string
+      description: |-
+        Native blockchain address in its canonical format for the specified chain.
+        Format varies by chain namespace.
+    ChainAddress:
+      type: object
+      properties:
+        chain:
+          type: string
+          description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+        address:
+          type: string
+          description: The address in its native format for the specified chain
+      required:
+        - chain
+        - address
     Amount:
       type: string
       pattern: ^[0-9]+$
@@ -106,13 +122,31 @@ components:
       type: object
       properties:
         user:
-          type: string
-          pattern: ^0x0001[a-fA-F0-9]+$
-          description: The address providing the input assets
+          type: object
+          properties:
+            chain:
+              type: string
+              description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+            address:
+              type: string
+              description: The address in its native format for the specified chain
+          required:
+            - chain
+            - address
+          description: The CAIP-350 address of the user providing the input assets
         asset:
-          type: string
-          pattern: ^0x0001[a-fA-F0-9]+$
-          description: The token/asset being provided as input
+          type: object
+          properties:
+            chain:
+              type: string
+              description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+            address:
+              type: string
+              description: The address in its native format for the specified chain
+          required:
+            - chain
+            - address
+          description: The CAIP-350 address of the token/asset being provided as input
         amount:
           type: string
           pattern: ^[0-9]+$
@@ -152,13 +186,31 @@ components:
       type: object
       properties:
         receiver:
-          type: string
-          pattern: ^0x0001[a-fA-F0-9]+$
-          description: The address that will receive the output assets
+          type: object
+          properties:
+            chain:
+              type: string
+              description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+            address:
+              type: string
+              description: The address in its native format for the specified chain
+          required:
+            - chain
+            - address
+          description: The CAIP-350 address that will receive the output assets
         asset:
-          type: string
-          pattern: ^0x0001[a-fA-F0-9]+$
-          description: The token/asset to be received as output
+          type: object
+          properties:
+            chain:
+              type: string
+              description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+            address:
+              type: string
+              description: The address in its native format for the specified chain
+          required:
+            - chain
+            - address
+          description: The CAIP-350 address of the token/asset to be received as output
         amount:
           type: string
           pattern: ^[0-9]+$
@@ -215,11 +267,17 @@ components:
       type: object
       properties:
         user:
-          type: string
-          pattern: ^0x0001[a-fA-F0-9]+$
-          description: |-
-            Cross-chain compatible address format per EIP-7930 version 1 encoded format (0x0001 + chain ID + address) for
-            unambiguous cross-chain identification.
+          type: object
+          properties:
+            chain:
+              type: string
+              description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+            address:
+              type: string
+              description: The address in its native format for the specified chain
+          required:
+            - chain
+            - address
         intent:
           type: object
           properties:
@@ -233,13 +291,31 @@ components:
                 type: object
                 properties:
                   user:
-                    type: string
-                    pattern: ^0x0001[a-fA-F0-9]+$
-                    description: The address providing the input assets
+                    type: object
+                    properties:
+                      chain:
+                        type: string
+                        description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                      address:
+                        type: string
+                        description: The address in its native format for the specified chain
+                    required:
+                      - chain
+                      - address
+                    description: The CAIP-350 address of the user providing the input assets
                   asset:
-                    type: string
-                    pattern: ^0x0001[a-fA-F0-9]+$
-                    description: The token/asset being provided as input
+                    type: object
+                    properties:
+                      chain:
+                        type: string
+                        description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                      address:
+                        type: string
+                        description: The address in its native format for the specified chain
+                    required:
+                      - chain
+                      - address
+                    description: The CAIP-350 address of the token/asset being provided as input
                   amount:
                     type: string
                     pattern: ^[0-9]+$
@@ -281,13 +357,31 @@ components:
                 type: object
                 properties:
                   receiver:
-                    type: string
-                    pattern: ^0x0001[a-fA-F0-9]+$
-                    description: The address that will receive the output assets
+                    type: object
+                    properties:
+                      chain:
+                        type: string
+                        description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                      address:
+                        type: string
+                        description: The address in its native format for the specified chain
+                    required:
+                      - chain
+                      - address
+                    description: The CAIP-350 address that will receive the output assets
                   asset:
-                    type: string
-                    pattern: ^0x0001[a-fA-F0-9]+$
-                    description: The token/asset to be received as output
+                    type: object
+                    properties:
+                      chain:
+                        type: string
+                        description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                      address:
+                        type: string
+                        description: The address in its native format for the specified chain
+                    required:
+                      - chain
+                      - address
+                    description: The CAIP-350 address of the token/asset to be received as output
                   amount:
                     type: string
                     pattern: ^[0-9]+$
@@ -724,11 +818,18 @@ components:
               type: object
               properties:
                 to:
-                  type: string
-                  pattern: ^0x0001[a-fA-F0-9]+$
-                  description: |-
-                    Cross-chain compatible address format per EIP-7930 version 1 encoded format (0x0001 + chain ID + address) for
-                    unambiguous cross-chain identification.
+                  type: object
+                  properties:
+                    chain:
+                      type: string
+                      description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                    address:
+                      type: string
+                      description: The address in its native format for the specified chain
+                  required:
+                    - chain
+                    - address
+                  description: Destination contract in CAIP-350 address format
                 data:
                   type: array
                   items:
@@ -749,23 +850,44 @@ components:
                     type: object
                     properties:
                       token:
-                        type: string
-                        pattern: ^0x0001[a-fA-F0-9]+$
-                        description: |-
-                          Cross-chain compatible address format per EIP-7930 version 1 encoded format (0x0001 + chain ID + address) for
-                          unambiguous cross-chain identification.
+                        type: object
+                        properties:
+                          chain:
+                            type: string
+                            description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                          address:
+                            type: string
+                            description: The address in its native format for the specified chain
+                        required:
+                          - chain
+                          - address
+                        description: Token address in CAIP-350 format
                       user:
-                        type: string
-                        pattern: ^0x0001[a-fA-F0-9]+$
-                        description: |-
-                          Cross-chain compatible address format per EIP-7930 version 1 encoded format (0x0001 + chain ID + address) for
-                          unambiguous cross-chain identification.
+                        type: object
+                        properties:
+                          chain:
+                            type: string
+                            description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                          address:
+                            type: string
+                            description: The address in its native format for the specified chain
+                        required:
+                          - chain
+                          - address
+                        description: User address in CAIP-350 format
                       spender:
-                        type: string
-                        pattern: ^0x0001[a-fA-F0-9]+$
-                        description: |-
-                          Cross-chain compatible address format per EIP-7930 version 1 encoded format (0x0001 + chain ID + address) for
-                          unambiguous cross-chain identification.
+                        type: object
+                        properties:
+                          chain:
+                            type: string
+                            description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                          address:
+                            type: string
+                            description: The address in its native format for the specified chain
+                        required:
+                          - chain
+                          - address
+                        description: Spender/settlement contract address in CAIP-350 format
                       required:
                         type: string
                         pattern: ^[0-9]+$
@@ -948,11 +1070,18 @@ components:
                   type: object
                   properties:
                     to:
-                      type: string
-                      pattern: ^0x0001[a-fA-F0-9]+$
-                      description: |-
-                        Cross-chain compatible address format per EIP-7930 version 1 encoded format (0x0001 + chain ID + address) for
-                        unambiguous cross-chain identification.
+                      type: object
+                      properties:
+                        chain:
+                          type: string
+                          description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                        address:
+                          type: string
+                          description: The address in its native format for the specified chain
+                      required:
+                        - chain
+                        - address
+                      description: Destination contract in CAIP-350 address format
                     data:
                       type: array
                       items:
@@ -973,23 +1102,44 @@ components:
                         type: object
                         properties:
                           token:
-                            type: string
-                            pattern: ^0x0001[a-fA-F0-9]+$
-                            description: |-
-                              Cross-chain compatible address format per EIP-7930 version 1 encoded format (0x0001 + chain ID + address) for
-                              unambiguous cross-chain identification.
+                            type: object
+                            properties:
+                              chain:
+                                type: string
+                                description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                              address:
+                                type: string
+                                description: The address in its native format for the specified chain
+                            required:
+                              - chain
+                              - address
+                            description: Token address in CAIP-350 format
                           user:
-                            type: string
-                            pattern: ^0x0001[a-fA-F0-9]+$
-                            description: |-
-                              Cross-chain compatible address format per EIP-7930 version 1 encoded format (0x0001 + chain ID + address) for
-                              unambiguous cross-chain identification.
+                            type: object
+                            properties:
+                              chain:
+                                type: string
+                                description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                              address:
+                                type: string
+                                description: The address in its native format for the specified chain
+                            required:
+                              - chain
+                              - address
+                            description: User address in CAIP-350 format
                           spender:
-                            type: string
-                            pattern: ^0x0001[a-fA-F0-9]+$
-                            description: |-
-                              Cross-chain compatible address format per EIP-7930 version 1 encoded format (0x0001 + chain ID + address) for
-                              unambiguous cross-chain identification.
+                            type: object
+                            properties:
+                              chain:
+                                type: string
+                                description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                              address:
+                                type: string
+                                description: The address in its native format for the specified chain
+                            required:
+                              - chain
+                              - address
+                            description: Spender/settlement contract address in CAIP-350 format
                           required:
                             type: string
                             pattern: ^[0-9]+$
@@ -1025,13 +1175,31 @@ components:
                 type: object
                 properties:
                   user:
-                    type: string
-                    pattern: ^0x0001[a-fA-F0-9]+$
-                    description: The address providing the input assets
+                    type: object
+                    properties:
+                      chain:
+                        type: string
+                        description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                      address:
+                        type: string
+                        description: The address in its native format for the specified chain
+                    required:
+                      - chain
+                      - address
+                    description: The CAIP-350 address of the user providing the input assets
                   asset:
-                    type: string
-                    pattern: ^0x0001[a-fA-F0-9]+$
-                    description: The token/asset being provided as input
+                    type: object
+                    properties:
+                      chain:
+                        type: string
+                        description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                      address:
+                        type: string
+                        description: The address in its native format for the specified chain
+                    required:
+                      - chain
+                      - address
+                    description: The CAIP-350 address of the token/asset being provided as input
                   amount:
                     type: string
                     pattern: ^[0-9]+$
@@ -1073,13 +1241,31 @@ components:
                 type: object
                 properties:
                   receiver:
-                    type: string
-                    pattern: ^0x0001[a-fA-F0-9]+$
-                    description: The address that will receive the output assets
+                    type: object
+                    properties:
+                      chain:
+                        type: string
+                        description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                      address:
+                        type: string
+                        description: The address in its native format for the specified chain
+                    required:
+                      - chain
+                      - address
+                    description: The CAIP-350 address that will receive the output assets
                   asset:
-                    type: string
-                    pattern: ^0x0001[a-fA-F0-9]+$
-                    description: The token/asset to be received as output
+                    type: object
+                    properties:
+                      chain:
+                        type: string
+                        description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                      address:
+                        type: string
+                        description: The address in its native format for the specified chain
+                    required:
+                      - chain
+                      - address
+                    description: The CAIP-350 address of the token/asset to be received as output
                   amount:
                     type: string
                     pattern: ^[0-9]+$
@@ -1136,13 +1322,31 @@ components:
             type: object
             properties:
               user:
-                type: string
-                pattern: ^0x0001[a-fA-F0-9]+$
-                description: The address providing the input assets
+                type: object
+                properties:
+                  chain:
+                    type: string
+                    description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                  address:
+                    type: string
+                    description: The address in its native format for the specified chain
+                required:
+                  - chain
+                  - address
+                description: The CAIP-350 address of the user providing the input assets
               asset:
-                type: string
-                pattern: ^0x0001[a-fA-F0-9]+$
-                description: The token/asset being provided as input
+                type: object
+                properties:
+                  chain:
+                    type: string
+                    description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                  address:
+                    type: string
+                    description: The address in its native format for the specified chain
+                required:
+                  - chain
+                  - address
+                description: The CAIP-350 address of the token/asset being provided as input
               amount:
                 type: string
                 pattern: ^[0-9]+$
@@ -1184,13 +1388,31 @@ components:
             type: object
             properties:
               receiver:
-                type: string
-                pattern: ^0x0001[a-fA-F0-9]+$
-                description: The address that will receive the output assets
+                type: object
+                properties:
+                  chain:
+                    type: string
+                    description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                  address:
+                    type: string
+                    description: The address in its native format for the specified chain
+                required:
+                  - chain
+                  - address
+                description: The CAIP-350 address that will receive the output assets
               asset:
-                type: string
-                pattern: ^0x0001[a-fA-F0-9]+$
-                description: The token/asset to be received as output
+                type: object
+                properties:
+                  chain:
+                    type: string
+                    description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                  address:
+                    type: string
+                    description: The address in its native format for the specified chain
+                required:
+                  - chain
+                  - address
+                description: The CAIP-350 address of the token/asset to be received as output
               amount:
                 type: string
                 pattern: ^[0-9]+$
@@ -1379,11 +1601,18 @@ components:
                         type: object
                         properties:
                           to:
-                            type: string
-                            pattern: ^0x0001[a-fA-F0-9]+$
-                            description: |-
-                              Cross-chain compatible address format per EIP-7930 version 1 encoded format (0x0001 + chain ID + address) for
-                              unambiguous cross-chain identification.
+                            type: object
+                            properties:
+                              chain:
+                                type: string
+                                description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                              address:
+                                type: string
+                                description: The address in its native format for the specified chain
+                            required:
+                              - chain
+                              - address
+                            description: Destination contract in CAIP-350 address format
                           data:
                             type: array
                             items:
@@ -1404,23 +1633,44 @@ components:
                               type: object
                               properties:
                                 token:
-                                  type: string
-                                  pattern: ^0x0001[a-fA-F0-9]+$
-                                  description: |-
-                                    Cross-chain compatible address format per EIP-7930 version 1 encoded format (0x0001 + chain ID + address) for
-                                    unambiguous cross-chain identification.
+                                  type: object
+                                  properties:
+                                    chain:
+                                      type: string
+                                      description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                    address:
+                                      type: string
+                                      description: The address in its native format for the specified chain
+                                  required:
+                                    - chain
+                                    - address
+                                  description: Token address in CAIP-350 format
                                 user:
-                                  type: string
-                                  pattern: ^0x0001[a-fA-F0-9]+$
-                                  description: |-
-                                    Cross-chain compatible address format per EIP-7930 version 1 encoded format (0x0001 + chain ID + address) for
-                                    unambiguous cross-chain identification.
+                                  type: object
+                                  properties:
+                                    chain:
+                                      type: string
+                                      description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                    address:
+                                      type: string
+                                      description: The address in its native format for the specified chain
+                                  required:
+                                    - chain
+                                    - address
+                                  description: User address in CAIP-350 format
                                 spender:
-                                  type: string
-                                  pattern: ^0x0001[a-fA-F0-9]+$
-                                  description: |-
-                                    Cross-chain compatible address format per EIP-7930 version 1 encoded format (0x0001 + chain ID + address) for
-                                    unambiguous cross-chain identification.
+                                  type: object
+                                  properties:
+                                    chain:
+                                      type: string
+                                      description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                    address:
+                                      type: string
+                                      description: The address in its native format for the specified chain
+                                  required:
+                                    - chain
+                                    - address
+                                  description: Spender/settlement contract address in CAIP-350 format
                                 required:
                                   type: string
                                   pattern: ^[0-9]+$
@@ -1456,13 +1706,31 @@ components:
                       type: object
                       properties:
                         user:
-                          type: string
-                          pattern: ^0x0001[a-fA-F0-9]+$
-                          description: The address providing the input assets
+                          type: object
+                          properties:
+                            chain:
+                              type: string
+                              description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                            address:
+                              type: string
+                              description: The address in its native format for the specified chain
+                          required:
+                            - chain
+                            - address
+                          description: The CAIP-350 address of the user providing the input assets
                         asset:
-                          type: string
-                          pattern: ^0x0001[a-fA-F0-9]+$
-                          description: The token/asset being provided as input
+                          type: object
+                          properties:
+                            chain:
+                              type: string
+                              description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                            address:
+                              type: string
+                              description: The address in its native format for the specified chain
+                          required:
+                            - chain
+                            - address
+                          description: The CAIP-350 address of the token/asset being provided as input
                         amount:
                           type: string
                           pattern: ^[0-9]+$
@@ -1504,13 +1772,31 @@ components:
                       type: object
                       properties:
                         receiver:
-                          type: string
-                          pattern: ^0x0001[a-fA-F0-9]+$
-                          description: The address that will receive the output assets
+                          type: object
+                          properties:
+                            chain:
+                              type: string
+                              description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                            address:
+                              type: string
+                              description: The address in its native format for the specified chain
+                          required:
+                            - chain
+                            - address
+                          description: The CAIP-350 address that will receive the output assets
                         asset:
-                          type: string
-                          pattern: ^0x0001[a-fA-F0-9]+$
-                          description: The token/asset to be received as output
+                          type: object
+                          properties:
+                            chain:
+                              type: string
+                              description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                            address:
+                              type: string
+                              description: The address in its native format for the specified chain
+                          required:
+                            - chain
+                            - address
+                          description: The CAIP-350 address of the token/asset to be received as output
                         amount:
                           type: string
                           pattern: ^[0-9]+$
@@ -1724,11 +2010,18 @@ components:
                   type: object
                   properties:
                     to:
-                      type: string
-                      pattern: ^0x0001[a-fA-F0-9]+$
-                      description: |-
-                        Cross-chain compatible address format per EIP-7930 version 1 encoded format (0x0001 + chain ID + address) for
-                        unambiguous cross-chain identification.
+                      type: object
+                      properties:
+                        chain:
+                          type: string
+                          description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                        address:
+                          type: string
+                          description: The address in its native format for the specified chain
+                      required:
+                        - chain
+                        - address
+                      description: Destination contract in CAIP-350 address format
                     data:
                       type: array
                       items:
@@ -1749,23 +2042,44 @@ components:
                         type: object
                         properties:
                           token:
-                            type: string
-                            pattern: ^0x0001[a-fA-F0-9]+$
-                            description: |-
-                              Cross-chain compatible address format per EIP-7930 version 1 encoded format (0x0001 + chain ID + address) for
-                              unambiguous cross-chain identification.
+                            type: object
+                            properties:
+                              chain:
+                                type: string
+                                description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                              address:
+                                type: string
+                                description: The address in its native format for the specified chain
+                            required:
+                              - chain
+                              - address
+                            description: Token address in CAIP-350 format
                           user:
-                            type: string
-                            pattern: ^0x0001[a-fA-F0-9]+$
-                            description: |-
-                              Cross-chain compatible address format per EIP-7930 version 1 encoded format (0x0001 + chain ID + address) for
-                              unambiguous cross-chain identification.
+                            type: object
+                            properties:
+                              chain:
+                                type: string
+                                description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                              address:
+                                type: string
+                                description: The address in its native format for the specified chain
+                            required:
+                              - chain
+                              - address
+                            description: User address in CAIP-350 format
                           spender:
-                            type: string
-                            pattern: ^0x0001[a-fA-F0-9]+$
-                            description: |-
-                              Cross-chain compatible address format per EIP-7930 version 1 encoded format (0x0001 + chain ID + address) for
-                              unambiguous cross-chain identification.
+                            type: object
+                            properties:
+                              chain:
+                                type: string
+                                description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                              address:
+                                type: string
+                                description: The address in its native format for the specified chain
+                            required:
+                              - chain
+                              - address
+                            description: Spender/settlement contract address in CAIP-350 format
                           required:
                             type: string
                             pattern: ^[0-9]+$
@@ -1879,9 +2193,18 @@ components:
       type: object
       properties:
         asset:
-          type: string
-          pattern: ^0x0001[a-fA-F0-9]+$
-          description: The token/asset identifier, may include chain information
+          type: object
+          properties:
+            chain:
+              type: string
+              description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+            address:
+              type: string
+              description: The address in its native format for the specified chain
+          required:
+            - chain
+            - address
+          description: The token/asset identifier with chain information
         amount:
           type: string
           pattern: ^[0-9]+$
@@ -1948,9 +2271,18 @@ components:
             type: object
             properties:
               asset:
-                type: string
-                pattern: ^0x0001[a-fA-F0-9]+$
-                description: The token/asset identifier, may include chain information
+                type: object
+                properties:
+                  chain:
+                    type: string
+                    description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                  address:
+                    type: string
+                    description: The address in its native format for the specified chain
+                required:
+                  - chain
+                  - address
+                description: The token/asset identifier with chain information
               amount:
                 type: string
                 pattern: ^[0-9]+$
@@ -1963,9 +2295,18 @@ components:
             type: object
             properties:
               asset:
-                type: string
-                pattern: ^0x0001[a-fA-F0-9]+$
-                description: The token/asset identifier, may include chain information
+                type: object
+                properties:
+                  chain:
+                    type: string
+                    description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                  address:
+                    type: string
+                    description: The address in its native format for the specified chain
+                required:
+                  - chain
+                  - address
+                description: The token/asset identifier with chain information
               amount:
                 type: string
                 pattern: ^[0-9]+$
@@ -2017,11 +2358,17 @@ paths:
               type: object
               properties:
                 user:
-                  type: string
-                  pattern: ^0x0001[a-fA-F0-9]+$
-                  description: |-
-                    Cross-chain compatible address format per EIP-7930 version 1 encoded format (0x0001 + chain ID + address) for
-                    unambiguous cross-chain identification.
+                  type: object
+                  properties:
+                    chain:
+                      type: string
+                      description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                    address:
+                      type: string
+                      description: The address in its native format for the specified chain
+                  required:
+                    - chain
+                    - address
                 intent:
                   type: object
                   properties:
@@ -2035,13 +2382,31 @@ paths:
                         type: object
                         properties:
                           user:
-                            type: string
-                            pattern: ^0x0001[a-fA-F0-9]+$
-                            description: The address providing the input assets
+                            type: object
+                            properties:
+                              chain:
+                                type: string
+                                description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                              address:
+                                type: string
+                                description: The address in its native format for the specified chain
+                            required:
+                              - chain
+                              - address
+                            description: The CAIP-350 address of the user providing the input assets
                           asset:
-                            type: string
-                            pattern: ^0x0001[a-fA-F0-9]+$
-                            description: The token/asset being provided as input
+                            type: object
+                            properties:
+                              chain:
+                                type: string
+                                description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                              address:
+                                type: string
+                                description: The address in its native format for the specified chain
+                            required:
+                              - chain
+                              - address
+                            description: The CAIP-350 address of the token/asset being provided as input
                           amount:
                             type: string
                             pattern: ^[0-9]+$
@@ -2083,13 +2448,31 @@ paths:
                         type: object
                         properties:
                           receiver:
-                            type: string
-                            pattern: ^0x0001[a-fA-F0-9]+$
-                            description: The address that will receive the output assets
+                            type: object
+                            properties:
+                              chain:
+                                type: string
+                                description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                              address:
+                                type: string
+                                description: The address in its native format for the specified chain
+                            required:
+                              - chain
+                              - address
+                            description: The CAIP-350 address that will receive the output assets
                           asset:
-                            type: string
-                            pattern: ^0x0001[a-fA-F0-9]+$
-                            description: The token/asset to be received as output
+                            type: object
+                            properties:
+                              chain:
+                                type: string
+                                description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                              address:
+                                type: string
+                                description: The address in its native format for the specified chain
+                            required:
+                              - chain
+                              - address
+                            description: The CAIP-350 address of the token/asset to be received as output
                           amount:
                             type: string
                             pattern: ^[0-9]+$
@@ -2387,11 +2770,18 @@ paths:
                                   type: object
                                   properties:
                                     to:
-                                      type: string
-                                      pattern: ^0x0001[a-fA-F0-9]+$
-                                      description: |-
-                                        Cross-chain compatible address format per EIP-7930 version 1 encoded format (0x0001 + chain ID + address) for
-                                        unambiguous cross-chain identification.
+                                      type: object
+                                      properties:
+                                        chain:
+                                          type: string
+                                          description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                        address:
+                                          type: string
+                                          description: The address in its native format for the specified chain
+                                      required:
+                                        - chain
+                                        - address
+                                      description: Destination contract in CAIP-350 address format
                                     data:
                                       type: array
                                       items:
@@ -2412,23 +2802,44 @@ paths:
                                         type: object
                                         properties:
                                           token:
-                                            type: string
-                                            pattern: ^0x0001[a-fA-F0-9]+$
-                                            description: |-
-                                              Cross-chain compatible address format per EIP-7930 version 1 encoded format (0x0001 + chain ID + address) for
-                                              unambiguous cross-chain identification.
+                                            type: object
+                                            properties:
+                                              chain:
+                                                type: string
+                                                description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                              address:
+                                                type: string
+                                                description: The address in its native format for the specified chain
+                                            required:
+                                              - chain
+                                              - address
+                                            description: Token address in CAIP-350 format
                                           user:
-                                            type: string
-                                            pattern: ^0x0001[a-fA-F0-9]+$
-                                            description: |-
-                                              Cross-chain compatible address format per EIP-7930 version 1 encoded format (0x0001 + chain ID + address) for
-                                              unambiguous cross-chain identification.
+                                            type: object
+                                            properties:
+                                              chain:
+                                                type: string
+                                                description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                              address:
+                                                type: string
+                                                description: The address in its native format for the specified chain
+                                            required:
+                                              - chain
+                                              - address
+                                            description: User address in CAIP-350 format
                                           spender:
-                                            type: string
-                                            pattern: ^0x0001[a-fA-F0-9]+$
-                                            description: |-
-                                              Cross-chain compatible address format per EIP-7930 version 1 encoded format (0x0001 + chain ID + address) for
-                                              unambiguous cross-chain identification.
+                                            type: object
+                                            properties:
+                                              chain:
+                                                type: string
+                                                description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                              address:
+                                                type: string
+                                                description: The address in its native format for the specified chain
+                                            required:
+                                              - chain
+                                              - address
+                                            description: Spender/settlement contract address in CAIP-350 format
                                           required:
                                             type: string
                                             pattern: ^[0-9]+$
@@ -2464,13 +2875,31 @@ paths:
                                 type: object
                                 properties:
                                   user:
-                                    type: string
-                                    pattern: ^0x0001[a-fA-F0-9]+$
-                                    description: The address providing the input assets
+                                    type: object
+                                    properties:
+                                      chain:
+                                        type: string
+                                        description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                      address:
+                                        type: string
+                                        description: The address in its native format for the specified chain
+                                    required:
+                                      - chain
+                                      - address
+                                    description: The CAIP-350 address of the user providing the input assets
                                   asset:
-                                    type: string
-                                    pattern: ^0x0001[a-fA-F0-9]+$
-                                    description: The token/asset being provided as input
+                                    type: object
+                                    properties:
+                                      chain:
+                                        type: string
+                                        description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                      address:
+                                        type: string
+                                        description: The address in its native format for the specified chain
+                                    required:
+                                      - chain
+                                      - address
+                                    description: The CAIP-350 address of the token/asset being provided as input
                                   amount:
                                     type: string
                                     pattern: ^[0-9]+$
@@ -2512,13 +2941,31 @@ paths:
                                 type: object
                                 properties:
                                   receiver:
-                                    type: string
-                                    pattern: ^0x0001[a-fA-F0-9]+$
-                                    description: The address that will receive the output assets
+                                    type: object
+                                    properties:
+                                      chain:
+                                        type: string
+                                        description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                      address:
+                                        type: string
+                                        description: The address in its native format for the specified chain
+                                    required:
+                                      - chain
+                                      - address
+                                    description: The CAIP-350 address that will receive the output assets
                                   asset:
-                                    type: string
-                                    pattern: ^0x0001[a-fA-F0-9]+$
-                                    description: The token/asset to be received as output
+                                    type: object
+                                    properties:
+                                      chain:
+                                        type: string
+                                        description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                      address:
+                                        type: string
+                                        description: The address in its native format for the specified chain
+                                    required:
+                                      - chain
+                                      - address
+                                    description: The CAIP-350 address of the token/asset to be received as output
                                   amount:
                                     type: string
                                     pattern: ^[0-9]+$
@@ -2745,11 +3192,18 @@ paths:
                           type: object
                           properties:
                             to:
-                              type: string
-                              pattern: ^0x0001[a-fA-F0-9]+$
-                              description: |-
-                                Cross-chain compatible address format per EIP-7930 version 1 encoded format (0x0001 + chain ID + address) for
-                                unambiguous cross-chain identification.
+                              type: object
+                              properties:
+                                chain:
+                                  type: string
+                                  description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                address:
+                                  type: string
+                                  description: The address in its native format for the specified chain
+                              required:
+                                - chain
+                                - address
+                              description: Destination contract in CAIP-350 address format
                             data:
                               type: array
                               items:
@@ -2770,23 +3224,44 @@ paths:
                                 type: object
                                 properties:
                                   token:
-                                    type: string
-                                    pattern: ^0x0001[a-fA-F0-9]+$
-                                    description: |-
-                                      Cross-chain compatible address format per EIP-7930 version 1 encoded format (0x0001 + chain ID + address) for
-                                      unambiguous cross-chain identification.
+                                    type: object
+                                    properties:
+                                      chain:
+                                        type: string
+                                        description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                      address:
+                                        type: string
+                                        description: The address in its native format for the specified chain
+                                    required:
+                                      - chain
+                                      - address
+                                    description: Token address in CAIP-350 format
                                   user:
-                                    type: string
-                                    pattern: ^0x0001[a-fA-F0-9]+$
-                                    description: |-
-                                      Cross-chain compatible address format per EIP-7930 version 1 encoded format (0x0001 + chain ID + address) for
-                                      unambiguous cross-chain identification.
+                                    type: object
+                                    properties:
+                                      chain:
+                                        type: string
+                                        description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                      address:
+                                        type: string
+                                        description: The address in its native format for the specified chain
+                                    required:
+                                      - chain
+                                      - address
+                                    description: User address in CAIP-350 format
                                   spender:
-                                    type: string
-                                    pattern: ^0x0001[a-fA-F0-9]+$
-                                    description: |-
-                                      Cross-chain compatible address format per EIP-7930 version 1 encoded format (0x0001 + chain ID + address) for
-                                      unambiguous cross-chain identification.
+                                    type: object
+                                    properties:
+                                      chain:
+                                        type: string
+                                        description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                      address:
+                                        type: string
+                                        description: The address in its native format for the specified chain
+                                    required:
+                                      - chain
+                                      - address
+                                    description: Spender/settlement contract address in CAIP-350 format
                                   required:
                                     type: string
                                     pattern: ^[0-9]+$
@@ -2934,9 +3409,18 @@ paths:
                       type: object
                       properties:
                         asset:
-                          type: string
-                          pattern: ^0x0001[a-fA-F0-9]+$
-                          description: The token/asset identifier, may include chain information
+                          type: object
+                          properties:
+                            chain:
+                              type: string
+                              description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                            address:
+                              type: string
+                              description: The address in its native format for the specified chain
+                          required:
+                            - chain
+                            - address
+                          description: The token/asset identifier with chain information
                         amount:
                           type: string
                           pattern: ^[0-9]+$
@@ -2949,9 +3433,18 @@ paths:
                       type: object
                       properties:
                         asset:
-                          type: string
-                          pattern: ^0x0001[a-fA-F0-9]+$
-                          description: The token/asset identifier, may include chain information
+                          type: object
+                          properties:
+                            chain:
+                              type: string
+                              description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                            address:
+                              type: string
+                              description: The address in its native format for the specified chain
+                          required:
+                            - chain
+                            - address
+                          description: The token/asset identifier with chain information
                         amount:
                           type: string
                           pattern: ^[0-9]+$

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -17,22 +17,22 @@ components:
     Chain:
       type: string
       description: |-
-        Chain identifier following CAIP-2 standard (namespace:reference format).
+        Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`).
         For EVM chains, uses eip155 namespace with chain ID.
     NativeAddress:
       type: string
       description: |-
-        Native blockchain address in its canonical format for the specified chain.
+        The address in its standard text representation for the specified chain.
         Format varies by chain namespace.
     ChainAddress:
       type: object
       properties:
         chain:
           type: string
-          description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+          description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
         address:
           type: string
-          description: The address in its native format for the specified chain
+          description: The address in its standard text representation for the specified chain
       required:
         - chain
         - address
@@ -126,27 +126,27 @@ components:
           properties:
             chain:
               type: string
-              description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+              description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
             address:
               type: string
-              description: The address in its native format for the specified chain
+              description: The address in its standard text representation for the specified chain
           required:
             - chain
             - address
-          description: The CAIP-350 address of the user providing the input assets
+          description: The chain-specific address of the account providing the input assets
         asset:
           type: object
           properties:
             chain:
               type: string
-              description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+              description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
             address:
               type: string
-              description: The address in its native format for the specified chain
+              description: The address in its standard text representation for the specified chain
           required:
             - chain
             - address
-          description: The CAIP-350 address of the token/asset being provided as input
+          description: The chain-specific address of the token/asset being provided as input
         amount:
           type: string
           pattern: ^[0-9]+$
@@ -190,27 +190,27 @@ components:
           properties:
             chain:
               type: string
-              description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+              description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
             address:
               type: string
-              description: The address in its native format for the specified chain
+              description: The address in its standard text representation for the specified chain
           required:
             - chain
             - address
-          description: The CAIP-350 address that will receive the output assets
+          description: The chain-specific address of the account that will receive the output assets
         asset:
           type: object
           properties:
             chain:
               type: string
-              description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+              description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
             address:
               type: string
-              description: The address in its native format for the specified chain
+              description: The address in its standard text representation for the specified chain
           required:
             - chain
             - address
-          description: The CAIP-350 address of the token/asset to be received as output
+          description: The chain-specific address of the token/asset to be received as output
         amount:
           type: string
           pattern: ^[0-9]+$
@@ -271,10 +271,10 @@ components:
           properties:
             chain:
               type: string
-              description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+              description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
             address:
               type: string
-              description: The address in its native format for the specified chain
+              description: The address in its standard text representation for the specified chain
           required:
             - chain
             - address
@@ -295,27 +295,27 @@ components:
                     properties:
                       chain:
                         type: string
-                        description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                       address:
                         type: string
-                        description: The address in its native format for the specified chain
+                        description: The address in its standard text representation for the specified chain
                     required:
                       - chain
                       - address
-                    description: The CAIP-350 address of the user providing the input assets
+                    description: The chain-specific address of the account providing the input assets
                   asset:
                     type: object
                     properties:
                       chain:
                         type: string
-                        description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                       address:
                         type: string
-                        description: The address in its native format for the specified chain
+                        description: The address in its standard text representation for the specified chain
                     required:
                       - chain
                       - address
-                    description: The CAIP-350 address of the token/asset being provided as input
+                    description: The chain-specific address of the token/asset being provided as input
                   amount:
                     type: string
                     pattern: ^[0-9]+$
@@ -361,27 +361,27 @@ components:
                     properties:
                       chain:
                         type: string
-                        description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                       address:
                         type: string
-                        description: The address in its native format for the specified chain
+                        description: The address in its standard text representation for the specified chain
                     required:
                       - chain
                       - address
-                    description: The CAIP-350 address that will receive the output assets
+                    description: The chain-specific address of the account that will receive the output assets
                   asset:
                     type: object
                     properties:
                       chain:
                         type: string
-                        description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                       address:
                         type: string
-                        description: The address in its native format for the specified chain
+                        description: The address in its standard text representation for the specified chain
                     required:
                       - chain
                       - address
-                    description: The CAIP-350 address of the token/asset to be received as output
+                    description: The chain-specific address of the token/asset to be received as output
                   amount:
                     type: string
                     pattern: ^[0-9]+$
@@ -822,10 +822,10 @@ components:
                   properties:
                     chain:
                       type: string
-                      description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                      description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                     address:
                       type: string
-                      description: The address in its native format for the specified chain
+                      description: The address in its standard text representation for the specified chain
                   required:
                     - chain
                     - address
@@ -854,10 +854,10 @@ components:
                         properties:
                           chain:
                             type: string
-                            description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                            description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                           address:
                             type: string
-                            description: The address in its native format for the specified chain
+                            description: The address in its standard text representation for the specified chain
                         required:
                           - chain
                           - address
@@ -867,10 +867,10 @@ components:
                         properties:
                           chain:
                             type: string
-                            description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                            description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                           address:
                             type: string
-                            description: The address in its native format for the specified chain
+                            description: The address in its standard text representation for the specified chain
                         required:
                           - chain
                           - address
@@ -880,10 +880,10 @@ components:
                         properties:
                           chain:
                             type: string
-                            description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                            description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                           address:
                             type: string
-                            description: The address in its native format for the specified chain
+                            description: The address in its standard text representation for the specified chain
                         required:
                           - chain
                           - address
@@ -1074,10 +1074,10 @@ components:
                       properties:
                         chain:
                           type: string
-                          description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                          description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                         address:
                           type: string
-                          description: The address in its native format for the specified chain
+                          description: The address in its standard text representation for the specified chain
                       required:
                         - chain
                         - address
@@ -1106,10 +1106,10 @@ components:
                             properties:
                               chain:
                                 type: string
-                                description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                               address:
                                 type: string
-                                description: The address in its native format for the specified chain
+                                description: The address in its standard text representation for the specified chain
                             required:
                               - chain
                               - address
@@ -1119,10 +1119,10 @@ components:
                             properties:
                               chain:
                                 type: string
-                                description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                               address:
                                 type: string
-                                description: The address in its native format for the specified chain
+                                description: The address in its standard text representation for the specified chain
                             required:
                               - chain
                               - address
@@ -1132,10 +1132,10 @@ components:
                             properties:
                               chain:
                                 type: string
-                                description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                               address:
                                 type: string
-                                description: The address in its native format for the specified chain
+                                description: The address in its standard text representation for the specified chain
                             required:
                               - chain
                               - address
@@ -1179,27 +1179,27 @@ components:
                     properties:
                       chain:
                         type: string
-                        description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                       address:
                         type: string
-                        description: The address in its native format for the specified chain
+                        description: The address in its standard text representation for the specified chain
                     required:
                       - chain
                       - address
-                    description: The CAIP-350 address of the user providing the input assets
+                    description: The chain-specific address of the account providing the input assets
                   asset:
                     type: object
                     properties:
                       chain:
                         type: string
-                        description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                       address:
                         type: string
-                        description: The address in its native format for the specified chain
+                        description: The address in its standard text representation for the specified chain
                     required:
                       - chain
                       - address
-                    description: The CAIP-350 address of the token/asset being provided as input
+                    description: The chain-specific address of the token/asset being provided as input
                   amount:
                     type: string
                     pattern: ^[0-9]+$
@@ -1245,27 +1245,27 @@ components:
                     properties:
                       chain:
                         type: string
-                        description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                       address:
                         type: string
-                        description: The address in its native format for the specified chain
+                        description: The address in its standard text representation for the specified chain
                     required:
                       - chain
                       - address
-                    description: The CAIP-350 address that will receive the output assets
+                    description: The chain-specific address of the account that will receive the output assets
                   asset:
                     type: object
                     properties:
                       chain:
                         type: string
-                        description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                       address:
                         type: string
-                        description: The address in its native format for the specified chain
+                        description: The address in its standard text representation for the specified chain
                     required:
                       - chain
                       - address
-                    description: The CAIP-350 address of the token/asset to be received as output
+                    description: The chain-specific address of the token/asset to be received as output
                   amount:
                     type: string
                     pattern: ^[0-9]+$
@@ -1326,27 +1326,27 @@ components:
                 properties:
                   chain:
                     type: string
-                    description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                    description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                   address:
                     type: string
-                    description: The address in its native format for the specified chain
+                    description: The address in its standard text representation for the specified chain
                 required:
                   - chain
                   - address
-                description: The CAIP-350 address of the user providing the input assets
+                description: The chain-specific address of the account providing the input assets
               asset:
                 type: object
                 properties:
                   chain:
                     type: string
-                    description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                    description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                   address:
                     type: string
-                    description: The address in its native format for the specified chain
+                    description: The address in its standard text representation for the specified chain
                 required:
                   - chain
                   - address
-                description: The CAIP-350 address of the token/asset being provided as input
+                description: The chain-specific address of the token/asset being provided as input
               amount:
                 type: string
                 pattern: ^[0-9]+$
@@ -1392,27 +1392,27 @@ components:
                 properties:
                   chain:
                     type: string
-                    description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                    description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                   address:
                     type: string
-                    description: The address in its native format for the specified chain
+                    description: The address in its standard text representation for the specified chain
                 required:
                   - chain
                   - address
-                description: The CAIP-350 address that will receive the output assets
+                description: The chain-specific address of the account that will receive the output assets
               asset:
                 type: object
                 properties:
                   chain:
                     type: string
-                    description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                    description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                   address:
                     type: string
-                    description: The address in its native format for the specified chain
+                    description: The address in its standard text representation for the specified chain
                 required:
                   - chain
                   - address
-                description: The CAIP-350 address of the token/asset to be received as output
+                description: The chain-specific address of the token/asset to be received as output
               amount:
                 type: string
                 pattern: ^[0-9]+$
@@ -1605,10 +1605,10 @@ components:
                             properties:
                               chain:
                                 type: string
-                                description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                               address:
                                 type: string
-                                description: The address in its native format for the specified chain
+                                description: The address in its standard text representation for the specified chain
                             required:
                               - chain
                               - address
@@ -1637,10 +1637,10 @@ components:
                                   properties:
                                     chain:
                                       type: string
-                                      description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                      description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                                     address:
                                       type: string
-                                      description: The address in its native format for the specified chain
+                                      description: The address in its standard text representation for the specified chain
                                   required:
                                     - chain
                                     - address
@@ -1650,10 +1650,10 @@ components:
                                   properties:
                                     chain:
                                       type: string
-                                      description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                      description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                                     address:
                                       type: string
-                                      description: The address in its native format for the specified chain
+                                      description: The address in its standard text representation for the specified chain
                                   required:
                                     - chain
                                     - address
@@ -1663,10 +1663,10 @@ components:
                                   properties:
                                     chain:
                                       type: string
-                                      description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                      description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                                     address:
                                       type: string
-                                      description: The address in its native format for the specified chain
+                                      description: The address in its standard text representation for the specified chain
                                   required:
                                     - chain
                                     - address
@@ -1710,27 +1710,27 @@ components:
                           properties:
                             chain:
                               type: string
-                              description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                              description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                             address:
                               type: string
-                              description: The address in its native format for the specified chain
+                              description: The address in its standard text representation for the specified chain
                           required:
                             - chain
                             - address
-                          description: The CAIP-350 address of the user providing the input assets
+                          description: The chain-specific address of the account providing the input assets
                         asset:
                           type: object
                           properties:
                             chain:
                               type: string
-                              description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                              description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                             address:
                               type: string
-                              description: The address in its native format for the specified chain
+                              description: The address in its standard text representation for the specified chain
                           required:
                             - chain
                             - address
-                          description: The CAIP-350 address of the token/asset being provided as input
+                          description: The chain-specific address of the token/asset being provided as input
                         amount:
                           type: string
                           pattern: ^[0-9]+$
@@ -1776,27 +1776,27 @@ components:
                           properties:
                             chain:
                               type: string
-                              description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                              description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                             address:
                               type: string
-                              description: The address in its native format for the specified chain
+                              description: The address in its standard text representation for the specified chain
                           required:
                             - chain
                             - address
-                          description: The CAIP-350 address that will receive the output assets
+                          description: The chain-specific address of the account that will receive the output assets
                         asset:
                           type: object
                           properties:
                             chain:
                               type: string
-                              description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                              description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                             address:
                               type: string
-                              description: The address in its native format for the specified chain
+                              description: The address in its standard text representation for the specified chain
                           required:
                             - chain
                             - address
-                          description: The CAIP-350 address of the token/asset to be received as output
+                          description: The chain-specific address of the token/asset to be received as output
                         amount:
                           type: string
                           pattern: ^[0-9]+$
@@ -2014,10 +2014,10 @@ components:
                       properties:
                         chain:
                           type: string
-                          description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                          description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                         address:
                           type: string
-                          description: The address in its native format for the specified chain
+                          description: The address in its standard text representation for the specified chain
                       required:
                         - chain
                         - address
@@ -2046,10 +2046,10 @@ components:
                             properties:
                               chain:
                                 type: string
-                                description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                               address:
                                 type: string
-                                description: The address in its native format for the specified chain
+                                description: The address in its standard text representation for the specified chain
                             required:
                               - chain
                               - address
@@ -2059,10 +2059,10 @@ components:
                             properties:
                               chain:
                                 type: string
-                                description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                               address:
                                 type: string
-                                description: The address in its native format for the specified chain
+                                description: The address in its standard text representation for the specified chain
                             required:
                               - chain
                               - address
@@ -2072,10 +2072,10 @@ components:
                             properties:
                               chain:
                                 type: string
-                                description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                               address:
                                 type: string
-                                description: The address in its native format for the specified chain
+                                description: The address in its standard text representation for the specified chain
                             required:
                               - chain
                               - address
@@ -2197,10 +2197,10 @@ components:
           properties:
             chain:
               type: string
-              description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+              description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
             address:
               type: string
-              description: The address in its native format for the specified chain
+              description: The address in its standard text representation for the specified chain
           required:
             - chain
             - address
@@ -2275,10 +2275,10 @@ components:
                 properties:
                   chain:
                     type: string
-                    description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                    description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                   address:
                     type: string
-                    description: The address in its native format for the specified chain
+                    description: The address in its standard text representation for the specified chain
                 required:
                   - chain
                   - address
@@ -2299,10 +2299,10 @@ components:
                 properties:
                   chain:
                     type: string
-                    description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                    description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                   address:
                     type: string
-                    description: The address in its native format for the specified chain
+                    description: The address in its standard text representation for the specified chain
                 required:
                   - chain
                   - address
@@ -2362,10 +2362,10 @@ paths:
                   properties:
                     chain:
                       type: string
-                      description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                      description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                     address:
                       type: string
-                      description: The address in its native format for the specified chain
+                      description: The address in its standard text representation for the specified chain
                   required:
                     - chain
                     - address
@@ -2386,27 +2386,27 @@ paths:
                             properties:
                               chain:
                                 type: string
-                                description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                               address:
                                 type: string
-                                description: The address in its native format for the specified chain
+                                description: The address in its standard text representation for the specified chain
                             required:
                               - chain
                               - address
-                            description: The CAIP-350 address of the user providing the input assets
+                            description: The chain-specific address of the account providing the input assets
                           asset:
                             type: object
                             properties:
                               chain:
                                 type: string
-                                description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                               address:
                                 type: string
-                                description: The address in its native format for the specified chain
+                                description: The address in its standard text representation for the specified chain
                             required:
                               - chain
                               - address
-                            description: The CAIP-350 address of the token/asset being provided as input
+                            description: The chain-specific address of the token/asset being provided as input
                           amount:
                             type: string
                             pattern: ^[0-9]+$
@@ -2452,27 +2452,27 @@ paths:
                             properties:
                               chain:
                                 type: string
-                                description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                               address:
                                 type: string
-                                description: The address in its native format for the specified chain
+                                description: The address in its standard text representation for the specified chain
                             required:
                               - chain
                               - address
-                            description: The CAIP-350 address that will receive the output assets
+                            description: The chain-specific address of the account that will receive the output assets
                           asset:
                             type: object
                             properties:
                               chain:
                                 type: string
-                                description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                               address:
                                 type: string
-                                description: The address in its native format for the specified chain
+                                description: The address in its standard text representation for the specified chain
                             required:
                               - chain
                               - address
-                            description: The CAIP-350 address of the token/asset to be received as output
+                            description: The chain-specific address of the token/asset to be received as output
                           amount:
                             type: string
                             pattern: ^[0-9]+$
@@ -2774,10 +2774,10 @@ paths:
                                       properties:
                                         chain:
                                           type: string
-                                          description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                          description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                                         address:
                                           type: string
-                                          description: The address in its native format for the specified chain
+                                          description: The address in its standard text representation for the specified chain
                                       required:
                                         - chain
                                         - address
@@ -2806,10 +2806,10 @@ paths:
                                             properties:
                                               chain:
                                                 type: string
-                                                description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                                               address:
                                                 type: string
-                                                description: The address in its native format for the specified chain
+                                                description: The address in its standard text representation for the specified chain
                                             required:
                                               - chain
                                               - address
@@ -2819,10 +2819,10 @@ paths:
                                             properties:
                                               chain:
                                                 type: string
-                                                description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                                               address:
                                                 type: string
-                                                description: The address in its native format for the specified chain
+                                                description: The address in its standard text representation for the specified chain
                                             required:
                                               - chain
                                               - address
@@ -2832,10 +2832,10 @@ paths:
                                             properties:
                                               chain:
                                                 type: string
-                                                description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                                               address:
                                                 type: string
-                                                description: The address in its native format for the specified chain
+                                                description: The address in its standard text representation for the specified chain
                                             required:
                                               - chain
                                               - address
@@ -2879,27 +2879,27 @@ paths:
                                     properties:
                                       chain:
                                         type: string
-                                        description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                                       address:
                                         type: string
-                                        description: The address in its native format for the specified chain
+                                        description: The address in its standard text representation for the specified chain
                                     required:
                                       - chain
                                       - address
-                                    description: The CAIP-350 address of the user providing the input assets
+                                    description: The chain-specific address of the account providing the input assets
                                   asset:
                                     type: object
                                     properties:
                                       chain:
                                         type: string
-                                        description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                                       address:
                                         type: string
-                                        description: The address in its native format for the specified chain
+                                        description: The address in its standard text representation for the specified chain
                                     required:
                                       - chain
                                       - address
-                                    description: The CAIP-350 address of the token/asset being provided as input
+                                    description: The chain-specific address of the token/asset being provided as input
                                   amount:
                                     type: string
                                     pattern: ^[0-9]+$
@@ -2945,27 +2945,27 @@ paths:
                                     properties:
                                       chain:
                                         type: string
-                                        description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                                       address:
                                         type: string
-                                        description: The address in its native format for the specified chain
+                                        description: The address in its standard text representation for the specified chain
                                     required:
                                       - chain
                                       - address
-                                    description: The CAIP-350 address that will receive the output assets
+                                    description: The chain-specific address of the account that will receive the output assets
                                   asset:
                                     type: object
                                     properties:
                                       chain:
                                         type: string
-                                        description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                                       address:
                                         type: string
-                                        description: The address in its native format for the specified chain
+                                        description: The address in its standard text representation for the specified chain
                                     required:
                                       - chain
                                       - address
-                                    description: The CAIP-350 address of the token/asset to be received as output
+                                    description: The chain-specific address of the token/asset to be received as output
                                   amount:
                                     type: string
                                     pattern: ^[0-9]+$
@@ -3196,10 +3196,10 @@ paths:
                               properties:
                                 chain:
                                   type: string
-                                  description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                  description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                                 address:
                                   type: string
-                                  description: The address in its native format for the specified chain
+                                  description: The address in its standard text representation for the specified chain
                               required:
                                 - chain
                                 - address
@@ -3228,10 +3228,10 @@ paths:
                                     properties:
                                       chain:
                                         type: string
-                                        description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                                       address:
                                         type: string
-                                        description: The address in its native format for the specified chain
+                                        description: The address in its standard text representation for the specified chain
                                     required:
                                       - chain
                                       - address
@@ -3241,10 +3241,10 @@ paths:
                                     properties:
                                       chain:
                                         type: string
-                                        description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                                       address:
                                         type: string
-                                        description: The address in its native format for the specified chain
+                                        description: The address in its standard text representation for the specified chain
                                     required:
                                       - chain
                                       - address
@@ -3254,10 +3254,10 @@ paths:
                                     properties:
                                       chain:
                                         type: string
-                                        description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                                       address:
                                         type: string
-                                        description: The address in its native format for the specified chain
+                                        description: The address in its standard text representation for the specified chain
                                     required:
                                       - chain
                                       - address
@@ -3413,10 +3413,10 @@ paths:
                           properties:
                             chain:
                               type: string
-                              description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                              description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                             address:
                               type: string
-                              description: The address in its native format for the specified chain
+                              description: The address in its standard text representation for the specified chain
                           required:
                             - chain
                             - address
@@ -3437,10 +3437,10 @@ paths:
                           properties:
                             chain:
                               type: string
-                              description: The blockchain network identifier in CAIP-2 format (namespace:reference)
+                              description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
                             address:
                               type: string
-                              description: The address in its native format for the specified chain
+                              description: The address in its standard text representation for the specified chain
                           required:
                             - chain
                             - address

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -785,45 +785,18 @@ components:
                   items:
                     type: object
                     properties:
+                      chain:
+                        type: string
+                        description: The chain where the allowance check applies
                       token:
-                        type: object
-                        properties:
-                          chain:
-                            type: string
-                            description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                          address:
-                            type: string
-                            description: The address in its standard text representation for the specified chain
-                        required:
-                          - chain
-                          - address
-                        description: Token address in CAIP-350 format
+                        type: string
+                        description: The address of the token requiring allowance
                       user:
-                        type: object
-                        properties:
-                          chain:
-                            type: string
-                            description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                          address:
-                            type: string
-                            description: The address in its standard text representation for the specified chain
-                        required:
-                          - chain
-                          - address
-                        description: User address in CAIP-350 format
+                        type: string
+                        description: The address of the user granting the allowance
                       spender:
-                        type: object
-                        properties:
-                          chain:
-                            type: string
-                            description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                          address:
-                            type: string
-                            description: The address in its standard text representation for the specified chain
-                        required:
-                          - chain
-                          - address
-                        description: Spender/settlement contract address in CAIP-350 format
+                        type: string
+                        description: The address of the spender/settlement contract
                       required:
                         type: string
                         pattern: ^[0-9]+$
@@ -832,6 +805,7 @@ components:
                           (e.g., uint256). Always represents the smallest unit of the token (wei for ETH,
                           satoshi for BTC, etc.). No decimals or scientific notation allowed.
                     required:
+                      - chain
                       - token
                       - user
                       - spender
@@ -1037,45 +1011,18 @@ components:
                       items:
                         type: object
                         properties:
+                          chain:
+                            type: string
+                            description: The chain where the allowance check applies
                           token:
-                            type: object
-                            properties:
-                              chain:
-                                type: string
-                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                              address:
-                                type: string
-                                description: The address in its standard text representation for the specified chain
-                            required:
-                              - chain
-                              - address
-                            description: Token address in CAIP-350 format
+                            type: string
+                            description: The address of the token requiring allowance
                           user:
-                            type: object
-                            properties:
-                              chain:
-                                type: string
-                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                              address:
-                                type: string
-                                description: The address in its standard text representation for the specified chain
-                            required:
-                              - chain
-                              - address
-                            description: User address in CAIP-350 format
+                            type: string
+                            description: The address of the user granting the allowance
                           spender:
-                            type: object
-                            properties:
-                              chain:
-                                type: string
-                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                              address:
-                                type: string
-                                description: The address in its standard text representation for the specified chain
-                            required:
-                              - chain
-                              - address
-                            description: Spender/settlement contract address in CAIP-350 format
+                            type: string
+                            description: The address of the spender/settlement contract
                           required:
                             type: string
                             pattern: ^[0-9]+$
@@ -1084,6 +1031,7 @@ components:
                               (e.g., uint256). Always represents the smallest unit of the token (wei for ETH,
                               satoshi for BTC, etc.). No decimals or scientific notation allowed.
                         required:
+                          - chain
                           - token
                           - user
                           - spender
@@ -1504,45 +1452,18 @@ components:
                             items:
                               type: object
                               properties:
+                                chain:
+                                  type: string
+                                  description: The chain where the allowance check applies
                                 token:
-                                  type: object
-                                  properties:
-                                    chain:
-                                      type: string
-                                      description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                                    address:
-                                      type: string
-                                      description: The address in its standard text representation for the specified chain
-                                  required:
-                                    - chain
-                                    - address
-                                  description: Token address in CAIP-350 format
+                                  type: string
+                                  description: The address of the token requiring allowance
                                 user:
-                                  type: object
-                                  properties:
-                                    chain:
-                                      type: string
-                                      description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                                    address:
-                                      type: string
-                                      description: The address in its standard text representation for the specified chain
-                                  required:
-                                    - chain
-                                    - address
-                                  description: User address in CAIP-350 format
+                                  type: string
+                                  description: The address of the user granting the allowance
                                 spender:
-                                  type: object
-                                  properties:
-                                    chain:
-                                      type: string
-                                      description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                                    address:
-                                      type: string
-                                      description: The address in its standard text representation for the specified chain
-                                  required:
-                                    - chain
-                                    - address
-                                  description: Spender/settlement contract address in CAIP-350 format
+                                  type: string
+                                  description: The address of the spender/settlement contract
                                 required:
                                   type: string
                                   pattern: ^[0-9]+$
@@ -1551,6 +1472,7 @@ components:
                                     (e.g., uint256). Always represents the smallest unit of the token (wei for ETH,
                                     satoshi for BTC, etc.). No decimals or scientific notation allowed.
                               required:
+                                - chain
                                 - token
                                 - user
                                 - spender
@@ -1881,45 +1803,18 @@ components:
                       items:
                         type: object
                         properties:
+                          chain:
+                            type: string
+                            description: The chain where the allowance check applies
                           token:
-                            type: object
-                            properties:
-                              chain:
-                                type: string
-                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                              address:
-                                type: string
-                                description: The address in its standard text representation for the specified chain
-                            required:
-                              - chain
-                              - address
-                            description: Token address in CAIP-350 format
+                            type: string
+                            description: The address of the token requiring allowance
                           user:
-                            type: object
-                            properties:
-                              chain:
-                                type: string
-                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                              address:
-                                type: string
-                                description: The address in its standard text representation for the specified chain
-                            required:
-                              - chain
-                              - address
-                            description: User address in CAIP-350 format
+                            type: string
+                            description: The address of the user granting the allowance
                           spender:
-                            type: object
-                            properties:
-                              chain:
-                                type: string
-                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                              address:
-                                type: string
-                                description: The address in its standard text representation for the specified chain
-                            required:
-                              - chain
-                              - address
-                            description: Spender/settlement contract address in CAIP-350 format
+                            type: string
+                            description: The address of the spender/settlement contract
                           required:
                             type: string
                             pattern: ^[0-9]+$
@@ -1928,6 +1823,7 @@ components:
                               (e.g., uint256). Always represents the smallest unit of the token (wei for ETH,
                               satoshi for BTC, etc.). No decimals or scientific notation allowed.
                         required:
+                          - chain
                           - token
                           - user
                           - spender
@@ -2609,45 +2505,18 @@ paths:
                                       items:
                                         type: object
                                         properties:
+                                          chain:
+                                            type: string
+                                            description: The chain where the allowance check applies
                                           token:
-                                            type: object
-                                            properties:
-                                              chain:
-                                                type: string
-                                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                                              address:
-                                                type: string
-                                                description: The address in its standard text representation for the specified chain
-                                            required:
-                                              - chain
-                                              - address
-                                            description: Token address in CAIP-350 format
+                                            type: string
+                                            description: The address of the token requiring allowance
                                           user:
-                                            type: object
-                                            properties:
-                                              chain:
-                                                type: string
-                                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                                              address:
-                                                type: string
-                                                description: The address in its standard text representation for the specified chain
-                                            required:
-                                              - chain
-                                              - address
-                                            description: User address in CAIP-350 format
+                                            type: string
+                                            description: The address of the user granting the allowance
                                           spender:
-                                            type: object
-                                            properties:
-                                              chain:
-                                                type: string
-                                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                                              address:
-                                                type: string
-                                                description: The address in its standard text representation for the specified chain
-                                            required:
-                                              - chain
-                                              - address
-                                            description: Spender/settlement contract address in CAIP-350 format
+                                            type: string
+                                            description: The address of the spender/settlement contract
                                           required:
                                             type: string
                                             pattern: ^[0-9]+$
@@ -2656,6 +2525,7 @@ paths:
                                               (e.g., uint256). Always represents the smallest unit of the token (wei for ETH,
                                               satoshi for BTC, etc.). No decimals or scientific notation allowed.
                                         required:
+                                          - chain
                                           - token
                                           - user
                                           - spender
@@ -2999,45 +2869,18 @@ paths:
                               items:
                                 type: object
                                 properties:
+                                  chain:
+                                    type: string
+                                    description: The chain where the allowance check applies
                                   token:
-                                    type: object
-                                    properties:
-                                      chain:
-                                        type: string
-                                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                                      address:
-                                        type: string
-                                        description: The address in its standard text representation for the specified chain
-                                    required:
-                                      - chain
-                                      - address
-                                    description: Token address in CAIP-350 format
+                                    type: string
+                                    description: The address of the token requiring allowance
                                   user:
-                                    type: object
-                                    properties:
-                                      chain:
-                                        type: string
-                                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                                      address:
-                                        type: string
-                                        description: The address in its standard text representation for the specified chain
-                                    required:
-                                      - chain
-                                      - address
-                                    description: User address in CAIP-350 format
+                                    type: string
+                                    description: The address of the user granting the allowance
                                   spender:
-                                    type: object
-                                    properties:
-                                      chain:
-                                        type: string
-                                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                                      address:
-                                        type: string
-                                        description: The address in its standard text representation for the specified chain
-                                    required:
-                                      - chain
-                                      - address
-                                    description: Spender/settlement contract address in CAIP-350 format
+                                    type: string
+                                    description: The address of the spender/settlement contract
                                   required:
                                     type: string
                                     pattern: ^[0-9]+$
@@ -3046,6 +2889,7 @@ paths:
                                       (e.g., uint256). Always represents the smallest unit of the token (wei for ETH,
                                       satoshi for BTC, etc.). No decimals or scientific notation allowed.
                                 required:
+                                  - chain
                                   - token
                                   - user
                                   - spender


### PR DESCRIPTION
Related discussion: https://github.com/openintentsframework/oif-specs/issues/33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for CAIP-350 address formatting standard across the API
  * Added references to Intent and Quote APIs in documentation

* **Documentation**
  * Updated API discovery notes with CAIP-2 chain identifier format (e.g., eip155:1)
  * Expanded documentation with chain and address standards references

* **Refactor**
  * Migrated address format from EIP-7930 to CAIP-350
  * Updated API endpoints to use chain identifiers instead of numeric chain IDs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->