### PR TITLE
Separate chain in input/output

### DIFF
--- a/schemas/typescript/schemas.generated.ts
+++ b/schemas/typescript/schemas.generated.ts
@@ -79,11 +79,12 @@ export const originSubmissionSchema = z.object({
 });
 
 export const inputSchema = z.object({
-  user: chainAddressSchema.describe(
-    "The chain-specific address of the account providing the input assets",
+  chain: chainSchema.describe("The chain where the input assets reside"),
+  user: nativeAddressSchema.describe(
+    "The address of the account providing the input assets",
   ),
-  asset: chainAddressSchema.describe(
-    "The chain-specific address of the token/asset being provided as input",
+  asset: nativeAddressSchema.describe(
+    "The address of the token/asset being provided as input",
   ),
   amount: amountSchema
     .optional()
@@ -96,11 +97,14 @@ export const inputSchema = z.object({
 });
 
 export const outputSchema = z.object({
-  receiver: chainAddressSchema.describe(
-    "The chain-specific address of the account that will receive the output assets",
+  chain: chainSchema.describe(
+    "The chain where the output assets will be delivered",
   ),
-  asset: chainAddressSchema.describe(
-    "The chain-specific address of the token/asset to be received as output",
+  receiver: nativeAddressSchema.describe(
+    "The address of the account that will receive the output assets",
+  ),
+  asset: nativeAddressSchema.describe(
+    "The address of the token/asset to be received as output",
   ),
   amount: amountSchema
     .optional()
@@ -251,9 +255,7 @@ export const getOrderResponseSchema = z.object({
 });
 
 export const assetInfoSchema = z.object({
-  address: chainAddressSchema.describe(
-    "Chain-specific address for the asset",
-  ),
+  address: chainAddressSchema.describe("Chain-specific address for the asset"),
   symbol: z
     .string()
     .describe(

--- a/schemas/typescript/types.ts
+++ b/schemas/typescript/types.ts
@@ -138,33 +138,41 @@ export interface OriginSubmission {
 /**
  * Available input from a user
  * @description Specifies assets that a user is willing to provide as input for a swap or transfer.
- *              Represents the "from" side of the transaction.
- * @example Exact-input quote (user has 4000 USDC):
+ *              Represents the "from" side of the transaction. The user and asset are always on the
+ *              same chain, so the chain is specified once at the top level.
+ * @example Exact-input quote (user has 4000 USDC on Ethereum):
  * {
- *   user: { chain: "eip155:1", address: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" },
- *   asset: { chain: "eip155:1", address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" }, // USDC on Ethereum
+ *   chain: "eip155:1",
+ *   user: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+ *   asset: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC on Ethereum
  *   amount: "4000000000", // Exactly 4000 USDC
  *   lock: { kind: "the-compact" }
  * }
  * @example Exact-output quote (amount undefined, will be quoted):
  * {
- *   user: { chain: "eip155:1", address: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" },
- *   asset: { chain: "eip155:1", address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" }, // USDC
+ *   chain: "eip155:1",
+ *   user: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+ *   asset: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC
  *   amount: undefined, // Provider will quote how much USDC needed
  *   lock: { kind: "the-compact" }
  * }
  */
 export interface Input {
+  /**
+   * Chain identifier
+   * @description The chain where the input assets reside
+   */
+  chain: Chain;
   /** 
    * User address 
-   * @description The chain-specific address of the account providing the input assets
+   * @description The address of the account providing the input assets
    */
-  user: ChainAddress;
+  user: NativeAddress;
   /** 
    * Asset address
-   * @description The chain-specific address of the token/asset being provided as input
+   * @description The address of the token/asset being provided as input
    */
-  asset: ChainAddress;
+  asset: NativeAddress;
   /** 
    * Amount available
    * @description For quote requests:
@@ -184,33 +192,41 @@ export interface Input {
 /**
  * Requested output for a receiver
  * @description Specifies the desired assets and destination for a swap or transfer.
- *              Represents the "to" side of the transaction.
+ *              Represents the "to" side of the transaction. The receiver and asset are always on the
+ *              same chain, so the chain is specified once at the top level.
  * @example Exact-input quote (amount undefined, will be quoted):
  * {
- *   receiver: { chain: "eip155:1", address: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8" },
- *   asset: { chain: "eip155:1", address: "0xdAC17F958D2ee523a2206206994597C13D831ec7" }, // USDT on Ethereum  
+ *   chain: "eip155:1",
+ *   receiver: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8",
+ *   asset: "0xdAC17F958D2ee523a2206206994597C13D831ec7", // USDT on Ethereum  
  *   amount: undefined, // Provider will quote how much USDT user receives
  *   calldata: "0x095ea7b3..."
  * }
  * @example Exact-output quote (user wants exactly 4000 USDT):
  * {
- *   receiver: { chain: "eip155:1", address: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8" },
- *   asset: { chain: "eip155:1", address: "0xdAC17F958D2ee523a2206206994597C13D831ec7" }, // USDT
+ *   chain: "eip155:1",
+ *   receiver: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8",
+ *   asset: "0xdAC17F958D2ee523a2206206994597C13D831ec7", // USDT
  *   amount: "4000000000", // Exactly 4000 USDT requested
  *   calldata: null
  * }
  */
 export interface Output {
+  /**
+   * Chain identifier
+   * @description The chain where the output assets will be delivered
+   */
+  chain: Chain;
   /** 
    * Receiver address
-   * @description The chain-specific address of the account that will receive the output assets
+   * @description The address of the account that will receive the output assets
    */
-  receiver: ChainAddress;
+  receiver: NativeAddress;
   /** 
    * Asset address
-   * @description The chain-specific address of the token/asset to be received as output
+   * @description The address of the token/asset to be received as output
    */
-  asset: ChainAddress;
+  asset: NativeAddress;
   /** 
    * Amount requested
    * @description For quote requests:

--- a/schemas/typescript/types.ts
+++ b/schemas/typescript/types.ts
@@ -299,13 +299,15 @@ export type FailureHandlingMode =
  *   intent: {
  *     intentType: "oif-swap",
  *     inputs: [{ 
- *       user: { chain: "eip155:1", address: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8" },
- *       asset: { chain: "eip155:1", address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" }, // USDC
+ *       chain: "eip155:1",
+ *       user: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8",
+ *       asset: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC
  *       amount: "4000000000" // Exact: 4000 USDC
  *     }],
  *     outputs: [{ 
- *       receiver: { chain: "eip155:1", address: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8" },
- *       asset: { chain: "eip155:1", address: "0xdAC17F958D2ee523a2206206994597C13D831ec7" }, // USDT
+ *       chain: "eip155:1",
+ *       receiver: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8",
+ *       asset: "0xdAC17F958D2ee523a2206206994597C13D831ec7", // USDT
  *       amount: undefined // Provider will quote output amount
  *     }],
  *     swapType: "exact-input",
@@ -319,13 +321,15 @@ export type FailureHandlingMode =
  *   intent: {
  *     intentType: "oif-swap",
  *     inputs: [{
- *       user: { chain: "eip155:42161", address: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8" },
- *       asset: { chain: "eip155:42161", address: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831" }, // USDC on Arbitrum
+ *       chain: "eip155:42161",
+ *       user: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8",
+ *       asset: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831", // USDC on Arbitrum
  *       amount: undefined // Provider will quote input amount needed
  *     }],
  *     outputs: [{
- *       receiver: { chain: "eip155:42161", address: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8" },
- *       asset: { chain: "eip155:42161", address: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1" }, // WETH on Arbitrum
+ *       chain: "eip155:42161",
+ *       receiver: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8",
+ *       asset: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1", // WETH on Arbitrum
  *       amount: "2000000000000000000" // Exact: 2 WETH
  *     }],
  *     swapType: "exact-output",
@@ -554,9 +558,10 @@ export interface Oif3009Order {
  *   },
  *   checks: {
  *     allowances: [{
- *       token: { chain: "eip155:1", address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" },
- *       user: { chain: "eip155:1", address: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8" },
- *       spender: { chain: "eip155:1", address: "0x95ad61b0a150d79219dcf64e1e6cc01f0c0c8a4a" },
+ *       chain: "eip155:1",
+ *       token: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+ *       user: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb8",
+ *       spender: "0x95ad61b0a150d79219dcf64e1e6cc01f0c0c8a4a",
  *       required: "1000000000"
  *     }]
  *   }
@@ -586,12 +591,14 @@ export interface OifUserOpenIntentOrder {
      * @description Each item asserts that `user` has at least `required` balance and allowance for `spender` on `token`.
      */
     allowances: Array<{
-      /** Token address in CAIP-350 format */
-      token: ChainAddress;
-      /** User address in CAIP-350 format */
-      user: ChainAddress;
-      /** Spender/settlement contract address in CAIP-350 format */
-      spender: ChainAddress;
+      /** The chain where the allowance check applies */
+      chain: Chain;
+      /** The address of the token requiring allowance */
+      token: NativeAddress;
+      /** The address of the user granting the allowance */
+      user: NativeAddress;
+      /** The address of the spender/settlement contract */
+      spender: NativeAddress;
       /** Required allowance amount as string-encoded integer */
       required: Amount;
     }>;

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -31,9 +31,10 @@ const oifUserOpenIntentOrderSchema = z.object({
   checks: z.object({
     allowances: z.array(
       z.object({
-        token: schemas.chainAddressSchema.describe("Token address in CAIP-350 format"),
-        user: schemas.chainAddressSchema.describe("User address in CAIP-350 format"),
-        spender: schemas.chainAddressSchema.describe("Spender/settlement contract address in CAIP-350 format"),
+        chain: schemas.chainSchema.describe("The chain where the allowance check applies"),
+        token: schemas.nativeAddressSchema.describe("The address of the token requiring allowance"),
+        user: schemas.nativeAddressSchema.describe("The address of the user granting the allowance"),
+        spender: schemas.nativeAddressSchema.describe("The address of the spender/settlement contract"),
         required: schemas.amountSchema,
       })
     ),

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -121,32 +121,15 @@ components:
     Input:
       type: object
       properties:
+        chain:
+          type: string
+          description: The chain where the input assets reside
         user:
-          type: object
-          properties:
-            chain:
-              type: string
-              description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-            address:
-              type: string
-              description: The address in its standard text representation for the specified chain
-          required:
-            - chain
-            - address
-          description: The chain-specific address of the account providing the input assets
+          type: string
+          description: The address of the account providing the input assets
         asset:
-          type: object
-          properties:
-            chain:
-              type: string
-              description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-            address:
-              type: string
-              description: The address in its standard text representation for the specified chain
-          required:
-            - chain
-            - address
-          description: The chain-specific address of the token/asset being provided as input
+          type: string
+          description: The address of the token/asset being provided as input
         amount:
           type: string
           pattern: ^[0-9]+$
@@ -180,37 +163,21 @@ components:
             - kind
           description: Locking mechanism to use for securing the input assets
       required:
+        - chain
         - user
         - asset
     Output:
       type: object
       properties:
+        chain:
+          type: string
+          description: The chain where the output assets will be delivered
         receiver:
-          type: object
-          properties:
-            chain:
-              type: string
-              description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-            address:
-              type: string
-              description: The address in its standard text representation for the specified chain
-          required:
-            - chain
-            - address
-          description: The chain-specific address of the account that will receive the output assets
+          type: string
+          description: The address of the account that will receive the output assets
         asset:
-          type: object
-          properties:
-            chain:
-              type: string
-              description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-            address:
-              type: string
-              description: The address in its standard text representation for the specified chain
-          required:
-            - chain
-            - address
-          description: The chain-specific address of the token/asset to be received as output
+          type: string
+          description: The address of the token/asset to be received as output
         amount:
           type: string
           pattern: ^[0-9]+$
@@ -225,6 +192,7 @@ components:
             Encoded function call to be executed when delivering the output,
             enabling composability with other protocols
       required:
+        - chain
         - receiver
         - asset
     QuotePreference:
@@ -290,32 +258,15 @@ components:
               items:
                 type: object
                 properties:
+                  chain:
+                    type: string
+                    description: The chain where the input assets reside
                   user:
-                    type: object
-                    properties:
-                      chain:
-                        type: string
-                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                      address:
-                        type: string
-                        description: The address in its standard text representation for the specified chain
-                    required:
-                      - chain
-                      - address
-                    description: The chain-specific address of the account providing the input assets
+                    type: string
+                    description: The address of the account providing the input assets
                   asset:
-                    type: object
-                    properties:
-                      chain:
-                        type: string
-                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                      address:
-                        type: string
-                        description: The address in its standard text representation for the specified chain
-                    required:
-                      - chain
-                      - address
-                    description: The chain-specific address of the token/asset being provided as input
+                    type: string
+                    description: The address of the token/asset being provided as input
                   amount:
                     type: string
                     pattern: ^[0-9]+$
@@ -349,6 +300,7 @@ components:
                       - kind
                     description: Locking mechanism to use for securing the input assets
                 required:
+                  - chain
                   - user
                   - asset
             outputs:
@@ -356,32 +308,15 @@ components:
               items:
                 type: object
                 properties:
+                  chain:
+                    type: string
+                    description: The chain where the output assets will be delivered
                   receiver:
-                    type: object
-                    properties:
-                      chain:
-                        type: string
-                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                      address:
-                        type: string
-                        description: The address in its standard text representation for the specified chain
-                    required:
-                      - chain
-                      - address
-                    description: The chain-specific address of the account that will receive the output assets
+                    type: string
+                    description: The address of the account that will receive the output assets
                   asset:
-                    type: object
-                    properties:
-                      chain:
-                        type: string
-                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                      address:
-                        type: string
-                        description: The address in its standard text representation for the specified chain
-                    required:
-                      - chain
-                      - address
-                    description: The chain-specific address of the token/asset to be received as output
+                    type: string
+                    description: The address of the token/asset to be received as output
                   amount:
                     type: string
                     pattern: ^[0-9]+$
@@ -396,6 +331,7 @@ components:
                       Encoded function call to be executed when delivering the output,
                       enabling composability with other protocols
                 required:
+                  - chain
                   - receiver
                   - asset
             swapType:
@@ -1174,32 +1110,15 @@ components:
               items:
                 type: object
                 properties:
+                  chain:
+                    type: string
+                    description: The chain where the input assets reside
                   user:
-                    type: object
-                    properties:
-                      chain:
-                        type: string
-                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                      address:
-                        type: string
-                        description: The address in its standard text representation for the specified chain
-                    required:
-                      - chain
-                      - address
-                    description: The chain-specific address of the account providing the input assets
+                    type: string
+                    description: The address of the account providing the input assets
                   asset:
-                    type: object
-                    properties:
-                      chain:
-                        type: string
-                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                      address:
-                        type: string
-                        description: The address in its standard text representation for the specified chain
-                    required:
-                      - chain
-                      - address
-                    description: The chain-specific address of the token/asset being provided as input
+                    type: string
+                    description: The address of the token/asset being provided as input
                   amount:
                     type: string
                     pattern: ^[0-9]+$
@@ -1233,6 +1152,7 @@ components:
                       - kind
                     description: Locking mechanism to use for securing the input assets
                 required:
+                  - chain
                   - user
                   - asset
             outputs:
@@ -1240,32 +1160,15 @@ components:
               items:
                 type: object
                 properties:
+                  chain:
+                    type: string
+                    description: The chain where the output assets will be delivered
                   receiver:
-                    type: object
-                    properties:
-                      chain:
-                        type: string
-                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                      address:
-                        type: string
-                        description: The address in its standard text representation for the specified chain
-                    required:
-                      - chain
-                      - address
-                    description: The chain-specific address of the account that will receive the output assets
+                    type: string
+                    description: The address of the account that will receive the output assets
                   asset:
-                    type: object
-                    properties:
-                      chain:
-                        type: string
-                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                      address:
-                        type: string
-                        description: The address in its standard text representation for the specified chain
-                    required:
-                      - chain
-                      - address
-                    description: The chain-specific address of the token/asset to be received as output
+                    type: string
+                    description: The address of the token/asset to be received as output
                   amount:
                     type: string
                     pattern: ^[0-9]+$
@@ -1280,6 +1183,7 @@ components:
                       Encoded function call to be executed when delivering the output,
                       enabling composability with other protocols
                 required:
+                  - chain
                   - receiver
                   - asset
           required:
@@ -1321,32 +1225,15 @@ components:
           items:
             type: object
             properties:
+              chain:
+                type: string
+                description: The chain where the input assets reside
               user:
-                type: object
-                properties:
-                  chain:
-                    type: string
-                    description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                  address:
-                    type: string
-                    description: The address in its standard text representation for the specified chain
-                required:
-                  - chain
-                  - address
-                description: The chain-specific address of the account providing the input assets
+                type: string
+                description: The address of the account providing the input assets
               asset:
-                type: object
-                properties:
-                  chain:
-                    type: string
-                    description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                  address:
-                    type: string
-                    description: The address in its standard text representation for the specified chain
-                required:
-                  - chain
-                  - address
-                description: The chain-specific address of the token/asset being provided as input
+                type: string
+                description: The address of the token/asset being provided as input
               amount:
                 type: string
                 pattern: ^[0-9]+$
@@ -1380,6 +1267,7 @@ components:
                   - kind
                 description: Locking mechanism to use for securing the input assets
             required:
+              - chain
               - user
               - asset
         outputs:
@@ -1387,32 +1275,15 @@ components:
           items:
             type: object
             properties:
+              chain:
+                type: string
+                description: The chain where the output assets will be delivered
               receiver:
-                type: object
-                properties:
-                  chain:
-                    type: string
-                    description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                  address:
-                    type: string
-                    description: The address in its standard text representation for the specified chain
-                required:
-                  - chain
-                  - address
-                description: The chain-specific address of the account that will receive the output assets
+                type: string
+                description: The address of the account that will receive the output assets
               asset:
-                type: object
-                properties:
-                  chain:
-                    type: string
-                    description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                  address:
-                    type: string
-                    description: The address in its standard text representation for the specified chain
-                required:
-                  - chain
-                  - address
-                description: The chain-specific address of the token/asset to be received as output
+                type: string
+                description: The address of the token/asset to be received as output
               amount:
                 type: string
                 pattern: ^[0-9]+$
@@ -1427,6 +1298,7 @@ components:
                   Encoded function call to be executed when delivering the output,
                   enabling composability with other protocols
             required:
+              - chain
               - receiver
               - asset
       required:
@@ -1705,32 +1577,15 @@ components:
                     items:
                       type: object
                       properties:
+                        chain:
+                          type: string
+                          description: The chain where the input assets reside
                         user:
-                          type: object
-                          properties:
-                            chain:
-                              type: string
-                              description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                            address:
-                              type: string
-                              description: The address in its standard text representation for the specified chain
-                          required:
-                            - chain
-                            - address
-                          description: The chain-specific address of the account providing the input assets
+                          type: string
+                          description: The address of the account providing the input assets
                         asset:
-                          type: object
-                          properties:
-                            chain:
-                              type: string
-                              description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                            address:
-                              type: string
-                              description: The address in its standard text representation for the specified chain
-                          required:
-                            - chain
-                            - address
-                          description: The chain-specific address of the token/asset being provided as input
+                          type: string
+                          description: The address of the token/asset being provided as input
                         amount:
                           type: string
                           pattern: ^[0-9]+$
@@ -1764,6 +1619,7 @@ components:
                             - kind
                           description: Locking mechanism to use for securing the input assets
                       required:
+                        - chain
                         - user
                         - asset
                   outputs:
@@ -1771,32 +1627,15 @@ components:
                     items:
                       type: object
                       properties:
+                        chain:
+                          type: string
+                          description: The chain where the output assets will be delivered
                         receiver:
-                          type: object
-                          properties:
-                            chain:
-                              type: string
-                              description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                            address:
-                              type: string
-                              description: The address in its standard text representation for the specified chain
-                          required:
-                            - chain
-                            - address
-                          description: The chain-specific address of the account that will receive the output assets
+                          type: string
+                          description: The address of the account that will receive the output assets
                         asset:
-                          type: object
-                          properties:
-                            chain:
-                              type: string
-                              description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                            address:
-                              type: string
-                              description: The address in its standard text representation for the specified chain
-                          required:
-                            - chain
-                            - address
-                          description: The chain-specific address of the token/asset to be received as output
+                          type: string
+                          description: The address of the token/asset to be received as output
                         amount:
                           type: string
                           pattern: ^[0-9]+$
@@ -1811,6 +1650,7 @@ components:
                             Encoded function call to be executed when delivering the output,
                             enabling composability with other protocols
                       required:
+                        - chain
                         - receiver
                         - asset
                 required:
@@ -2381,32 +2221,15 @@ paths:
                       items:
                         type: object
                         properties:
+                          chain:
+                            type: string
+                            description: The chain where the input assets reside
                           user:
-                            type: object
-                            properties:
-                              chain:
-                                type: string
-                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                              address:
-                                type: string
-                                description: The address in its standard text representation for the specified chain
-                            required:
-                              - chain
-                              - address
-                            description: The chain-specific address of the account providing the input assets
+                            type: string
+                            description: The address of the account providing the input assets
                           asset:
-                            type: object
-                            properties:
-                              chain:
-                                type: string
-                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                              address:
-                                type: string
-                                description: The address in its standard text representation for the specified chain
-                            required:
-                              - chain
-                              - address
-                            description: The chain-specific address of the token/asset being provided as input
+                            type: string
+                            description: The address of the token/asset being provided as input
                           amount:
                             type: string
                             pattern: ^[0-9]+$
@@ -2440,6 +2263,7 @@ paths:
                               - kind
                             description: Locking mechanism to use for securing the input assets
                         required:
+                          - chain
                           - user
                           - asset
                     outputs:
@@ -2447,32 +2271,15 @@ paths:
                       items:
                         type: object
                         properties:
+                          chain:
+                            type: string
+                            description: The chain where the output assets will be delivered
                           receiver:
-                            type: object
-                            properties:
-                              chain:
-                                type: string
-                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                              address:
-                                type: string
-                                description: The address in its standard text representation for the specified chain
-                            required:
-                              - chain
-                              - address
-                            description: The chain-specific address of the account that will receive the output assets
+                            type: string
+                            description: The address of the account that will receive the output assets
                           asset:
-                            type: object
-                            properties:
-                              chain:
-                                type: string
-                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                              address:
-                                type: string
-                                description: The address in its standard text representation for the specified chain
-                            required:
-                              - chain
-                              - address
-                            description: The chain-specific address of the token/asset to be received as output
+                            type: string
+                            description: The address of the token/asset to be received as output
                           amount:
                             type: string
                             pattern: ^[0-9]+$
@@ -2487,6 +2294,7 @@ paths:
                               Encoded function call to be executed when delivering the output,
                               enabling composability with other protocols
                         required:
+                          - chain
                           - receiver
                           - asset
                     swapType:
@@ -2874,32 +2682,15 @@ paths:
                               items:
                                 type: object
                                 properties:
+                                  chain:
+                                    type: string
+                                    description: The chain where the input assets reside
                                   user:
-                                    type: object
-                                    properties:
-                                      chain:
-                                        type: string
-                                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                                      address:
-                                        type: string
-                                        description: The address in its standard text representation for the specified chain
-                                    required:
-                                      - chain
-                                      - address
-                                    description: The chain-specific address of the account providing the input assets
+                                    type: string
+                                    description: The address of the account providing the input assets
                                   asset:
-                                    type: object
-                                    properties:
-                                      chain:
-                                        type: string
-                                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                                      address:
-                                        type: string
-                                        description: The address in its standard text representation for the specified chain
-                                    required:
-                                      - chain
-                                      - address
-                                    description: The chain-specific address of the token/asset being provided as input
+                                    type: string
+                                    description: The address of the token/asset being provided as input
                                   amount:
                                     type: string
                                     pattern: ^[0-9]+$
@@ -2933,6 +2724,7 @@ paths:
                                       - kind
                                     description: Locking mechanism to use for securing the input assets
                                 required:
+                                  - chain
                                   - user
                                   - asset
                             outputs:
@@ -2940,32 +2732,15 @@ paths:
                               items:
                                 type: object
                                 properties:
+                                  chain:
+                                    type: string
+                                    description: The chain where the output assets will be delivered
                                   receiver:
-                                    type: object
-                                    properties:
-                                      chain:
-                                        type: string
-                                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                                      address:
-                                        type: string
-                                        description: The address in its standard text representation for the specified chain
-                                    required:
-                                      - chain
-                                      - address
-                                    description: The chain-specific address of the account that will receive the output assets
+                                    type: string
+                                    description: The address of the account that will receive the output assets
                                   asset:
-                                    type: object
-                                    properties:
-                                      chain:
-                                        type: string
-                                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                                      address:
-                                        type: string
-                                        description: The address in its standard text representation for the specified chain
-                                    required:
-                                      - chain
-                                      - address
-                                    description: The chain-specific address of the token/asset to be received as output
+                                    type: string
+                                    description: The address of the token/asset to be received as output
                                   amount:
                                     type: string
                                     pattern: ^[0-9]+$
@@ -2980,6 +2755,7 @@ paths:
                                       Encoded function call to be executed when delivering the output,
                                       enabling composability with other protocols
                                 required:
+                                  - chain
                                   - receiver
                                   - asset
                           required:

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -785,45 +785,18 @@ components:
                   items:
                     type: object
                     properties:
+                      chain:
+                        type: string
+                        description: The chain where the allowance check applies
                       token:
-                        type: object
-                        properties:
-                          chain:
-                            type: string
-                            description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                          address:
-                            type: string
-                            description: The address in its standard text representation for the specified chain
-                        required:
-                          - chain
-                          - address
-                        description: Token address in CAIP-350 format
+                        type: string
+                        description: The address of the token requiring allowance
                       user:
-                        type: object
-                        properties:
-                          chain:
-                            type: string
-                            description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                          address:
-                            type: string
-                            description: The address in its standard text representation for the specified chain
-                        required:
-                          - chain
-                          - address
-                        description: User address in CAIP-350 format
+                        type: string
+                        description: The address of the user granting the allowance
                       spender:
-                        type: object
-                        properties:
-                          chain:
-                            type: string
-                            description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                          address:
-                            type: string
-                            description: The address in its standard text representation for the specified chain
-                        required:
-                          - chain
-                          - address
-                        description: Spender/settlement contract address in CAIP-350 format
+                        type: string
+                        description: The address of the spender/settlement contract
                       required:
                         type: string
                         pattern: ^[0-9]+$
@@ -832,6 +805,7 @@ components:
                           (e.g., uint256). Always represents the smallest unit of the token (wei for ETH,
                           satoshi for BTC, etc.). No decimals or scientific notation allowed.
                     required:
+                      - chain
                       - token
                       - user
                       - spender
@@ -1037,45 +1011,18 @@ components:
                       items:
                         type: object
                         properties:
+                          chain:
+                            type: string
+                            description: The chain where the allowance check applies
                           token:
-                            type: object
-                            properties:
-                              chain:
-                                type: string
-                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                              address:
-                                type: string
-                                description: The address in its standard text representation for the specified chain
-                            required:
-                              - chain
-                              - address
-                            description: Token address in CAIP-350 format
+                            type: string
+                            description: The address of the token requiring allowance
                           user:
-                            type: object
-                            properties:
-                              chain:
-                                type: string
-                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                              address:
-                                type: string
-                                description: The address in its standard text representation for the specified chain
-                            required:
-                              - chain
-                              - address
-                            description: User address in CAIP-350 format
+                            type: string
+                            description: The address of the user granting the allowance
                           spender:
-                            type: object
-                            properties:
-                              chain:
-                                type: string
-                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                              address:
-                                type: string
-                                description: The address in its standard text representation for the specified chain
-                            required:
-                              - chain
-                              - address
-                            description: Spender/settlement contract address in CAIP-350 format
+                            type: string
+                            description: The address of the spender/settlement contract
                           required:
                             type: string
                             pattern: ^[0-9]+$
@@ -1084,6 +1031,7 @@ components:
                               (e.g., uint256). Always represents the smallest unit of the token (wei for ETH,
                               satoshi for BTC, etc.). No decimals or scientific notation allowed.
                         required:
+                          - chain
                           - token
                           - user
                           - spender
@@ -1504,45 +1452,18 @@ components:
                             items:
                               type: object
                               properties:
+                                chain:
+                                  type: string
+                                  description: The chain where the allowance check applies
                                 token:
-                                  type: object
-                                  properties:
-                                    chain:
-                                      type: string
-                                      description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                                    address:
-                                      type: string
-                                      description: The address in its standard text representation for the specified chain
-                                  required:
-                                    - chain
-                                    - address
-                                  description: Token address in CAIP-350 format
+                                  type: string
+                                  description: The address of the token requiring allowance
                                 user:
-                                  type: object
-                                  properties:
-                                    chain:
-                                      type: string
-                                      description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                                    address:
-                                      type: string
-                                      description: The address in its standard text representation for the specified chain
-                                  required:
-                                    - chain
-                                    - address
-                                  description: User address in CAIP-350 format
+                                  type: string
+                                  description: The address of the user granting the allowance
                                 spender:
-                                  type: object
-                                  properties:
-                                    chain:
-                                      type: string
-                                      description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                                    address:
-                                      type: string
-                                      description: The address in its standard text representation for the specified chain
-                                  required:
-                                    - chain
-                                    - address
-                                  description: Spender/settlement contract address in CAIP-350 format
+                                  type: string
+                                  description: The address of the spender/settlement contract
                                 required:
                                   type: string
                                   pattern: ^[0-9]+$
@@ -1551,6 +1472,7 @@ components:
                                     (e.g., uint256). Always represents the smallest unit of the token (wei for ETH,
                                     satoshi for BTC, etc.). No decimals or scientific notation allowed.
                               required:
+                                - chain
                                 - token
                                 - user
                                 - spender
@@ -1881,45 +1803,18 @@ components:
                       items:
                         type: object
                         properties:
+                          chain:
+                            type: string
+                            description: The chain where the allowance check applies
                           token:
-                            type: object
-                            properties:
-                              chain:
-                                type: string
-                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                              address:
-                                type: string
-                                description: The address in its standard text representation for the specified chain
-                            required:
-                              - chain
-                              - address
-                            description: Token address in CAIP-350 format
+                            type: string
+                            description: The address of the token requiring allowance
                           user:
-                            type: object
-                            properties:
-                              chain:
-                                type: string
-                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                              address:
-                                type: string
-                                description: The address in its standard text representation for the specified chain
-                            required:
-                              - chain
-                              - address
-                            description: User address in CAIP-350 format
+                            type: string
+                            description: The address of the user granting the allowance
                           spender:
-                            type: object
-                            properties:
-                              chain:
-                                type: string
-                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                              address:
-                                type: string
-                                description: The address in its standard text representation for the specified chain
-                            required:
-                              - chain
-                              - address
-                            description: Spender/settlement contract address in CAIP-350 format
+                            type: string
+                            description: The address of the spender/settlement contract
                           required:
                             type: string
                             pattern: ^[0-9]+$
@@ -1928,6 +1823,7 @@ components:
                               (e.g., uint256). Always represents the smallest unit of the token (wei for ETH,
                               satoshi for BTC, etc.). No decimals or scientific notation allowed.
                         required:
+                          - chain
                           - token
                           - user
                           - spender
@@ -2609,45 +2505,18 @@ paths:
                                       items:
                                         type: object
                                         properties:
+                                          chain:
+                                            type: string
+                                            description: The chain where the allowance check applies
                                           token:
-                                            type: object
-                                            properties:
-                                              chain:
-                                                type: string
-                                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                                              address:
-                                                type: string
-                                                description: The address in its standard text representation for the specified chain
-                                            required:
-                                              - chain
-                                              - address
-                                            description: Token address in CAIP-350 format
+                                            type: string
+                                            description: The address of the token requiring allowance
                                           user:
-                                            type: object
-                                            properties:
-                                              chain:
-                                                type: string
-                                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                                              address:
-                                                type: string
-                                                description: The address in its standard text representation for the specified chain
-                                            required:
-                                              - chain
-                                              - address
-                                            description: User address in CAIP-350 format
+                                            type: string
+                                            description: The address of the user granting the allowance
                                           spender:
-                                            type: object
-                                            properties:
-                                              chain:
-                                                type: string
-                                                description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                                              address:
-                                                type: string
-                                                description: The address in its standard text representation for the specified chain
-                                            required:
-                                              - chain
-                                              - address
-                                            description: Spender/settlement contract address in CAIP-350 format
+                                            type: string
+                                            description: The address of the spender/settlement contract
                                           required:
                                             type: string
                                             pattern: ^[0-9]+$
@@ -2656,6 +2525,7 @@ paths:
                                               (e.g., uint256). Always represents the smallest unit of the token (wei for ETH,
                                               satoshi for BTC, etc.). No decimals or scientific notation allowed.
                                         required:
+                                          - chain
                                           - token
                                           - user
                                           - spender
@@ -2999,45 +2869,18 @@ paths:
                               items:
                                 type: object
                                 properties:
+                                  chain:
+                                    type: string
+                                    description: The chain where the allowance check applies
                                   token:
-                                    type: object
-                                    properties:
-                                      chain:
-                                        type: string
-                                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                                      address:
-                                        type: string
-                                        description: The address in its standard text representation for the specified chain
-                                    required:
-                                      - chain
-                                      - address
-                                    description: Token address in CAIP-350 format
+                                    type: string
+                                    description: The address of the token requiring allowance
                                   user:
-                                    type: object
-                                    properties:
-                                      chain:
-                                        type: string
-                                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                                      address:
-                                        type: string
-                                        description: The address in its standard text representation for the specified chain
-                                    required:
-                                      - chain
-                                      - address
-                                    description: User address in CAIP-350 format
+                                    type: string
+                                    description: The address of the user granting the allowance
                                   spender:
-                                    type: object
-                                    properties:
-                                      chain:
-                                        type: string
-                                        description: Chain identifier following the CAIP-350 chain identifier text representation (`<namespace>:<reference>`)
-                                      address:
-                                        type: string
-                                        description: The address in its standard text representation for the specified chain
-                                    required:
-                                      - chain
-                                      - address
-                                    description: Spender/settlement contract address in CAIP-350 format
+                                    type: string
+                                    description: The address of the spender/settlement contract
                                   required:
                                     type: string
                                     pattern: ^[0-9]+$
@@ -3046,6 +2889,7 @@ paths:
                                       (e.g., uint256). Always represents the smallest unit of the token (wei for ETH,
                                       satoshi for BTC, etc.). No decimals or scientific notation allowed.
                                 required:
+                                  - chain
                                   - token
                                   - user
                                   - spender


### PR DESCRIPTION
Before -- user/receiver and asset each carried their own {chain, address} pair (redundant chain):

input: 
`{  user:  { chain: "eip155:1", address: "0xUser..." },  asset: { chain: "eip155:1", address: "0xToken..." },  amount: "1000000"}`

After -- chain is hoisted to the top level, user/receiver and asset are plain NativeAddress strings:

input: 
`{  chain: "eip155:1",  user:  "0xUser...",  asset: "0xToken...",  amount: "1000000"}`