### PR TITLE
signature docs improve

### DIFF
--- a/schemas/typescript/types.ts
+++ b/schemas/typescript/types.ts
@@ -647,7 +647,7 @@ export interface PostOrderRequest {
    *
    * - **oif-user-open-v0**: No signature required (authorization handled at execution layer)
    */
-  signature: Uint8Array; // bytes in solidity
+  signature?: Uint8Array; // bytes in solidity, optional for oif-user-open-v0
   /** Optional quote identifier from a prior Get Quote response */
   quoteId?: string;
   /** Optional preference mirrored from quote about who submits and acceptable schemes */

--- a/schemas/typescript/types.ts
+++ b/schemas/typescript/types.ts
@@ -627,7 +627,26 @@ export interface GetQuoteResponse {
 export interface PostOrderRequest {
   /** EIP-712 typed data for a gasless cross-chain order */
   order: Order;
-  /** EIP-712 signature or equivalent */
+  /**
+   * Encoded signature for the order.
+   *
+   * The signature format depends on the order type and uses a prefix byte to indicate
+   * the signature scheme:
+   *
+   * - **oif-escrow-v0**: `0x00` prefix + 65-byte EIP-712 signature (Permit2 PermitBatchWitnessTransferFrom)
+   *   - Total length: 66 bytes
+   *   - Format: [0x00, r (32 bytes), s (32 bytes), v (1 byte)]
+   *
+   * - **oif-3009-v0**: `0x01` prefix + 65-byte EIP-712 signature (EIP-3009 TransferWithAuthorization)
+   *   - Total length: 66 bytes
+   *   - Format: [0x01, r (32 bytes), s (32 bytes), v (1 byte)]
+   *
+   * - **oif-resource-lock-v0**: `0x02` prefix + 65-byte EIP-712 signature (Compact BatchCompact)
+   *   - Total length: 66 bytes
+   *   - Format: [0x02, r (32 bytes), s (32 bytes), v (1 byte)]
+   *
+   * - **oif-user-open-v0**: No signature required (authorization handled at execution layer)
+   */
   signature: Uint8Array; // bytes in solidity
   /** Optional quote identifier from a prior Get Quote response */
   quoteId?: string;

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -71,18 +71,19 @@ const getQuoteResponseSchema = z.object({
   quotes: z.array(quoteSchema),
 });
 
-// Define PostOrderRequest schema manually since it uses Uint8Array[] which ts-to-zod can't handle
+// Define PostOrderRequest schema manually since it uses Uint8Array which ts-to-zod can't handle
 const postOrderRequestSchema = z.object({
   order: orderSchema.describe("EIP-712 typed data for a gasless cross-chain order"),
-  // Uint8Array represented as array of byte arrays
+  // Uint8Array represented as array of bytes (numbers 0-255)
   signature: z
-    .array(z.array(z.number()))
+    .array(z.number())
+    .optional()
     .describe(
-      "Encoded signature for the order. Format depends on order type with a prefix byte indicating the scheme: " +
+      "Encoded signature for the order. Optional for oif-user-open-v0 (authorization handled at execution layer). " +
+        "Format depends on order type with a prefix byte indicating the scheme: " +
         "oif-escrow-v0 (0x00 prefix + 65-byte EIP-712 Permit2 signature), " +
         "oif-3009-v0 (0x01 prefix + 65-byte EIP-3009 signature), " +
-        "oif-resource-lock-v0 (0x02 prefix + 65-byte Compact signature), " +
-        "oif-user-open-v0 (no signature required)",
+        "oif-resource-lock-v0 (0x02 prefix + 65-byte Compact signature)",
     ),
   quoteId: z
     .string()

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -74,10 +74,16 @@ const getQuoteResponseSchema = z.object({
 // Define PostOrderRequest schema manually since it uses Uint8Array[] which ts-to-zod can't handle
 const postOrderRequestSchema = z.object({
   order: orderSchema.describe("EIP-712 typed data for a gasless cross-chain order"),
-  // Uint8Array[] represented as array of byte arrays
+  // Uint8Array represented as array of byte arrays
   signature: z
     .array(z.array(z.number()))
-    .describe("EIP-712 signature or equivalent as array of byte arrays"),
+    .describe(
+      "Encoded signature for the order. Format depends on order type with a prefix byte indicating the scheme: " +
+        "oif-escrow-v0 (0x00 prefix + 65-byte EIP-712 Permit2 signature), " +
+        "oif-3009-v0 (0x01 prefix + 65-byte EIP-3009 signature), " +
+        "oif-resource-lock-v0 (0x02 prefix + 65-byte Compact signature), " +
+        "oif-user-open-v0 (no signature required)",
+    ),
   quoteId: z
     .string()
     .optional()

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -1791,7 +1791,7 @@ components:
             type: array
             items:
               type: number
-          description: EIP-712 signature or equivalent as array of byte arrays
+          description: 'Encoded signature for the order. Format depends on order type with a prefix byte indicating the scheme: oif-escrow-v0 (0x00 prefix + 65-byte EIP-712 Permit2 signature), oif-3009-v0 (0x01 prefix + 65-byte EIP-3009 signature), oif-resource-lock-v0 (0x02 prefix + 65-byte Compact signature), oif-user-open-v0 (no signature required)'
         quoteId:
           type: string
           description: Optional quote identifier from a prior Get Quote response
@@ -2812,7 +2812,7 @@ paths:
                     type: array
                     items:
                       type: number
-                  description: EIP-712 signature or equivalent as array of byte arrays
+                  description: 'Encoded signature for the order. Format depends on order type with a prefix byte indicating the scheme: oif-escrow-v0 (0x00 prefix + 65-byte EIP-712 Permit2 signature), oif-3009-v0 (0x01 prefix + 65-byte EIP-3009 signature), oif-resource-lock-v0 (0x02 prefix + 65-byte Compact signature), oif-user-open-v0 (no signature required)'
                 quoteId:
                   type: string
                   description: Optional quote identifier from a prior Get Quote response

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -1788,10 +1788,8 @@ components:
         signature:
           type: array
           items:
-            type: array
-            items:
-              type: number
-          description: 'Encoded signature for the order. Format depends on order type with a prefix byte indicating the scheme: oif-escrow-v0 (0x00 prefix + 65-byte EIP-712 Permit2 signature), oif-3009-v0 (0x01 prefix + 65-byte EIP-3009 signature), oif-resource-lock-v0 (0x02 prefix + 65-byte Compact signature), oif-user-open-v0 (no signature required)'
+            type: number
+          description: 'Encoded signature for the order. Optional for oif-user-open-v0 (authorization handled at execution layer). Format depends on order type with a prefix byte indicating the scheme: oif-escrow-v0 (0x00 prefix + 65-byte EIP-712 Permit2 signature), oif-3009-v0 (0x01 prefix + 65-byte EIP-3009 signature), oif-resource-lock-v0 (0x02 prefix + 65-byte Compact signature)'
         quoteId:
           type: string
           description: Optional quote identifier from a prior Get Quote response
@@ -1837,7 +1835,6 @@ components:
           description: Optional preference mirrored from quote about who submits and acceptable schemes
       required:
         - order
-        - signature
     PostOrderResponse:
       type: object
       properties:
@@ -2809,10 +2806,8 @@ paths:
                 signature:
                   type: array
                   items:
-                    type: array
-                    items:
-                      type: number
-                  description: 'Encoded signature for the order. Format depends on order type with a prefix byte indicating the scheme: oif-escrow-v0 (0x00 prefix + 65-byte EIP-712 Permit2 signature), oif-3009-v0 (0x01 prefix + 65-byte EIP-3009 signature), oif-resource-lock-v0 (0x02 prefix + 65-byte Compact signature), oif-user-open-v0 (no signature required)'
+                    type: number
+                  description: 'Encoded signature for the order. Optional for oif-user-open-v0 (authorization handled at execution layer). Format depends on order type with a prefix byte indicating the scheme: oif-escrow-v0 (0x00 prefix + 65-byte EIP-712 Permit2 signature), oif-3009-v0 (0x01 prefix + 65-byte EIP-3009 signature), oif-resource-lock-v0 (0x02 prefix + 65-byte Compact signature)'
                 quoteId:
                   type: string
                   description: Optional quote identifier from a prior Get Quote response
@@ -2858,7 +2853,6 @@ paths:
                   description: Optional preference mirrored from quote about who submits and acceptable schemes
               required:
                 - order
-                - signature
       responses:
         '200':
           description: Order accepted


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Signatures on order requests/responses are now optional and represented as a flat byte array with a single-byte prefix indicating the scheme.
* **Documentation**
  * Updated signature encoding details with explicit per-order-type prefixes and byte-length expectations; clarified that oif-user-open-v0 requires no signature.
* **Bug Fixes**
  * Removed signature from required fields in several order-related responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


solves #34 